### PR TITLE
Fix COMESEP link in docs & prefer HTTPS

### DIFF
--- a/docs/user-manual/swhv_sum.html
+++ b/docs/user-manual/swhv_sum.html
@@ -656,7 +656,7 @@
 </tbody>
 </table>
 
-<p>For the moment only two sources for events are used: the <a href="https://www.lmsal.com/hek/">Heliophysics Events Knowledgebase (HEK)</a> and the <a href="http://comesep.aeronomy.be">COMESEP</a> alert system.</p>
+<p>For the moment only two sources for events are used: the <a href="https://www.lmsal.com/hek/">Heliophysics Events Knowledgebase (HEK)</a> and the <a href="https://comesep.aeronomie.be">COMESEP</a> alert system.</p>
 
 <h3 id="enablingdisablingspaceweatherevents">Enabling/Disabling Space Weather Events</h3>
 

--- a/docs/user-manual/swhv_sum.mmd
+++ b/docs/user-manual/swhv_sum.mmd
@@ -437,7 +437,7 @@ JHelioviewer provides a way to download space weather related events. A selectio
 |                |                        | Geomag24                          |
 [Overview of the default event types][eventtypes]
 
-For the moment only two sources for events are used: the [Heliophysics Events Knowledgebase (HEK)](https://www.lmsal.com/hek/) and the [COMESEP](http://comesep.aeronomy.be) alert system.
+For the moment only two sources for events are used: the [Heliophysics Events Knowledgebase (HEK)](https://www.lmsal.com/hek/) and the [COMESEP](https://comesep.aeronomie.be) alert system.
 
 ## Enabling/Disabling Space Weather Events
 


### PR DESCRIPTION
Fix broken COMESEP links in documentation and update to use HTTPS (http://comesep.aeronomy.be -> https://comesep.aeronomie.be)

http://comesep.eu is also now registered for the project, but also still operates under the aeronomie.be domain, which I've opted to choose with for better consistency.