### PR TITLE
Environment variables control startup window size

### DIFF
--- a/docs/user-manual/swhv_sum.mmd
+++ b/docs/user-manual/swhv_sum.mmd
@@ -585,6 +585,12 @@ Several parts of the interface can be turned on and off under the Plugins headin
 | Click and Drag on Value-Axis    | Move Graph in Value                                      |
 
 
+# Environment variables [env]
+
+The following environment variables can be set to change the behavior of JHelioviewer:
+* **JHV_PREFERRED_WIDTH**: Preferred width of the window frame at startup
+* **JHV_PREFERRED_HEIGHT**: Preferred height of the window frame at startup
+
 # Troubleshooting [trouble]
 
 ## Out of Memory Problems [oom]

--- a/src/org/helioviewer/jhv/gui/JHVFrame.java
+++ b/src/org/helioviewer/jhv/gui/JHVFrame.java
@@ -6,6 +6,7 @@ import java.awt.GraphicsEnvironment;
 import java.awt.event.ActionEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.util.Optional;
 
 import javax.swing.JFrame;
 import javax.swing.JPanel;
@@ -148,7 +149,19 @@ public class JHVFrame {
         minSize.height = Math.min(minSize.height, maxSize.height);
 
         frame.setMinimumSize(minSize);
-        frame.setPreferredSize(new Dimension(maxSize.width - 100, maxSize.height - 100));
+        
+        int preferredWidth = Optional.ofNullable(System.getenv("JHV_PREFERRED_WIDTH"))
+                .map(Integer::parseInt)
+                .filter(w -> w > 0)
+                .orElse(maxSize.width - 100);
+                
+        int preferredHeight = Optional.ofNullable(System.getenv("JHV_PREFERRED_HEIGHT"))
+                .map(Integer::parseInt)
+                .filter(h -> h > 0)
+                .orElse(maxSize.height - 100);
+        
+        frame.setPreferredSize(new Dimension(preferredWidth, preferredHeight));
+        
         frame.setIconImage(IconBank.getIcon(IconBank.JHVIcon.HVLOGO_SMALL).getImage());
 
         return frame;


### PR DESCRIPTION
Instead of defaulting the window frame dimensions to `maxSize.width-100` and `maxSize.height-100` on startup, we now read from the environment variables `JHV_PREFERRED_WIDTH` and `JHV_PREFERRED_HEIGHT` first.

This allows me to start JHelioviewer in full-screen mode on startup. Especially useful inside a container without a windowing system where JHelioviewer can be the sole application.