### PR TITLE
Add the Radial Histogram Equalizing Filter (RHEF) with an Upsilon midtone control

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 - Improve flat-grid stability and grid label formatting
 - Adjust trajectory colors for white canvas (fixes #260)
 - Add a `New PUNCH Layer` source that loads FITS frames from the PUNCH archive at `umbra.nascom.nasa.gov/punch`
+- Add `RHEF` radial histogram equalizing filter with an Upsilon midtone control
 
 ### Timeline, events, and UI
 - Map HEK Flare Trigger events to Flare events (fixes #105)

--- a/resources/glsl/solarCommon.frag
+++ b/resources/glsl/solarCommon.frag
@@ -72,6 +72,8 @@ struct Display {
     vec2 brightness;
     vec2 radii;
     vec2 slit;
+    float upsilonLow;
+    float upsilonHigh;
 };
 
 layout(std140) uniform DisplayBlock {
@@ -151,6 +153,13 @@ vec4 getColor(const vec2 texcoord, const vec2 difftexcoord, const float factor) 
             blurredValue = blurredValue * BOOST + 0.5;
         }
         value = mix(value, blurredValue, sharpenMix);
+    }
+
+    if (display.upsilonLow != 1. || display.upsilonHigh != 1.) {
+        // Two-sided gamma about the median (Gilly & DeForest Eq. 2): upsilonLow and
+        // upsilonHigh independently set the curvature below and above I = 0.5
+        value = clamp(value, 0., 1.);
+        value = value < .5 ? .5 * pow(2. * value, display.upsilonLow) : 1. - .5 * pow(2. - 2. * value, display.upsilonHigh);
     }
 
     value += dither(texcoord);

--- a/src/org/helioviewer/jhv/image/FilterRHEF.java
+++ b/src/org/helioviewer/jhv/image/FilterRHEF.java
@@ -1,0 +1,119 @@
+package org.helioviewer.jhv.image;
+
+import java.util.Arrays;
+
+import javax.annotation.Nullable;
+
+import org.helioviewer.jhv.metadata.Region;
+import org.helioviewer.jhv.thread.ParallelRange;
+
+// Radial Histogram Equalizing Filter (Gilly & DeForest 2024): rank-equalizes pixel
+// values within ~1-pixel-wide annuli centered on the Sun, flattening the radial
+// brightness gradient while preserving the relative structure at each height.
+class FilterRHEF implements ImageFilter.Algorithm {
+
+    // Annuli with fewer valid pixels are passed through unfiltered
+    private static final int MIN_BIN_COUNT = 5;
+
+    @Override
+    public float[] filter(float[] data, int width, int height) {
+        return filter(data, width, height, null);
+    }
+
+    @Override
+    public float[] filter(float[] data, int width, int height, @Nullable Region region) {
+        if (width < 1 || height < 1)
+            return data;
+
+        // Buffer geometry in physical units; the region origin sits at the Sun center.
+        // Without a region, assume the Sun at the image center with pixel units.
+        double pixX, pixY, llx, lly;
+        if (region == null || !(region.width > 0) || !(region.height > 0)) {
+            pixX = 1;
+            pixY = 1;
+            llx = -.5 * width;
+            lly = -.5 * height;
+        } else {
+            pixX = region.width / width;
+            pixY = region.height / height;
+            llx = region.llx;
+            lly = region.lly;
+        }
+        double invBinWidth = 1 / Math.min(pixX, pixY); // ~1-pixel-wide annuli
+
+        double dxMax = Math.max(Math.abs(llx), Math.abs(llx + width * pixX));
+        double dyMax = Math.max(Math.abs(lly), Math.abs(lly + height * pixY));
+        int numBins = (int) (Math.sqrt(dxMax * dxMax + dyMax * dyMax) * invBinWidth) + 1;
+
+        int length = width * height;
+        int[] binOf = new int[length];
+        double[] dx2 = new double[width];
+        for (int x = 0; x < width; x++) {
+            double dx = llx + (x + .5) * pixX;
+            dx2[x] = dx * dx;
+        }
+        ParallelRange.run(height, (from, to) -> {
+            for (int y = from; y < to; y++) {
+                double dy = lly + (y + .5) * pixY;
+                double dy2 = dy * dy;
+                int rowBase = y * width;
+                for (int x = 0; x < width; x++) {
+                    binOf[rowBase + x] = (int) (Math.sqrt(dx2[x] + dy2) * invBinWidth);
+                }
+            }
+        });
+
+        // Counting sort of pixel indices by annulus
+        int[] offset = new int[numBins + 1];
+        for (int i = 0; i < length; i++)
+            offset[binOf[i] + 1]++;
+        for (int b = 0; b < numBins; b++)
+            offset[b + 1] += offset[b];
+
+        int[] order = new int[length];
+        int[] cursor = Arrays.copyOf(offset, numBins);
+        for (int i = 0; i < length; i++)
+            order[cursor[binOf[i]]++] = i;
+
+        float[] out = data.clone();
+        ParallelRange.run(numBins, (from, to) -> {
+            for (int b = from; b < to; b++) {
+                int lo = offset[b];
+                int hi = offset[b + 1];
+                if (hi - lo < MIN_BIN_COUNT)
+                    continue;
+
+                // Pack value bits with the pixel index; non-negative float bits sort numerically.
+                // Zero pixels (detector padding, occulters) are excluded and stay zero.
+                long[] packed = new long[hi - lo];
+                int n = 0;
+                for (int j = lo; j < hi; j++) {
+                    int idx = order[j];
+                    float v = data[idx];
+                    if (v > 0)
+                        packed[n++] = (long) Float.floatToRawIntBits(v) << 32 | idx;
+                }
+                if (n < MIN_BIN_COUNT)
+                    continue;
+
+                Arrays.sort(packed, 0, n);
+
+                // Equal values get their average rank, like scipy.stats.rankdata(method="average")
+                float invRange = 1f / (n - 1);
+                int i = 0;
+                while (i < n) {
+                    long bits = packed[i] >>> 32;
+                    int j = i;
+                    while (j + 1 < n && packed[j + 1] >>> 32 == bits)
+                        j++;
+                    float value = .5f * (i + j) * invRange;
+                    for (int k = i; k <= j; k++)
+                        out[(int) packed[k]] = value;
+                    i = j + 1;
+                }
+            }
+        });
+        return out;
+    }
+
+}

--- a/src/org/helioviewer/jhv/image/ImageBuffer.java
+++ b/src/org/helioviewer/jhv/image/ImageBuffer.java
@@ -5,6 +5,10 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ShortBuffer;
 
+import javax.annotation.Nullable;
+
+import org.helioviewer.jhv.metadata.Region;
+
 import org.lwjgl.system.MemoryUtil;
 
 public final class ImageBuffer {
@@ -30,25 +34,25 @@ public final class ImageBuffer {
     private volatile boolean explicitFreeProtected;
 
     public static ImageBuffer fromBytes(int width, int height, Format format, byte[] data) {
-        return fromBytes(width, height, format, data, ImageFilter.Type.None);
+        return fromBytes(width, height, format, data, ImageFilter.Type.None, null);
     }
 
-    public static ImageBuffer fromBytes(int width, int height, Format format, byte[] data, ImageFilter.Type filterType) {
+    public static ImageBuffer fromBytes(int width, int height, Format format, byte[] data, ImageFilter.Type filterType, @Nullable Region region) {
         if (format == Format.Gray16F)
             throw new IllegalArgumentException("Gray16F image buffers must be created from half-float data");
-        byte[] filtered = format == Format.RGBA32 ? data : ImageFilter.filter(data, width, height, filterType);
+        byte[] filtered = format == Format.RGBA32 ? data : ImageFilter.filter(data, width, height, filterType, region);
         return new ImageBuffer(width, height, format, allocateFrom(filtered));
     }
 
-    public static ImageBuffer fromShorts(int width, int height, Format format, short[] data, ImageFilter.Type filterType) {
+    public static ImageBuffer fromShorts(int width, int height, Format format, short[] data, ImageFilter.Type filterType, @Nullable Region region) {
         if (format != Format.Gray16F)
             throw new IllegalArgumentException("Only Gray16F image buffers can be created from half-float data");
-        short[] filtered = ImageFilter.filterHalfFloat(data, width, height, filterType);
+        short[] filtered = ImageFilter.filterHalfFloat(data, width, height, filterType, region);
         return new ImageBuffer(width, height, format, allocateFrom(filtered));
     }
 
-    public static WriteBuffer createWriteBuffer(int width, int height, Format format, ImageFilter.Type filterType) {
-        return new WriteBuffer(width, height, format, filterType);
+    public static WriteBuffer createWriteBuffer(int width, int height, Format format, ImageFilter.Type filterType, @Nullable Region region) {
+        return new WriteBuffer(width, height, format, filterType, region);
     }
 
     private ImageBuffer(int _width, int _height, Format _format, ByteBuffer _buffer) {
@@ -91,16 +95,18 @@ public final class ImageBuffer {
         private final int height;
         private final Format format;
         private final ImageFilter.Type filterType;
+        private final Region region;
         private final ImageBuffer directBuffer;
         private final byte[] byteArray;
         private final short[] shortArray;
         private final Buffer writeBuffer;
 
-        private WriteBuffer(int _width, int _height, Format _format, ImageFilter.Type _filterType) {
+        private WriteBuffer(int _width, int _height, Format _format, ImageFilter.Type _filterType, @Nullable Region _region) {
             width = _width;
             height = _height;
             format = _format;
             filterType = _filterType;
+            region = _region;
 
             if (usesDirectBuffer(format, filterType)) {
                 directBuffer = allocate(width, height, format);
@@ -132,8 +138,8 @@ public final class ImageBuffer {
             if (directBuffer != null)
                 return directBuffer;
             return shortArray != null
-                    ? fromShorts(width, height, format, shortArray, filterType)
-                    : fromBytes(width, height, format, byteArray, filterType);
+                    ? fromShorts(width, height, format, shortArray, filterType, region)
+                    : fromBytes(width, height, format, byteArray, filterType, region);
         }
 
         private static boolean usesDirectBuffer(Format format, ImageFilter.Type filterType) {

--- a/src/org/helioviewer/jhv/image/ImageFilter.java
+++ b/src/org/helioviewer/jhv/image/ImageFilter.java
@@ -1,5 +1,8 @@
 package org.helioviewer.jhv.image;
 
+import javax.annotation.Nullable;
+
+import org.helioviewer.jhv.metadata.Region;
 import org.helioviewer.jhv.thread.ParallelRange;
 
 //import com.google.common.base.Stopwatch;
@@ -9,7 +12,8 @@ public class ImageFilter {
     public enum Type {
         None("No filter", null),
         MGN("Multi-scale Gaussian normalization", new FilterMGN()),
-        WOW("Wavelet-optimized whitening", new FilterWOW());
+        WOW("Wavelet-optimized whitening", new FilterWOW()),
+        RHEF("Radial histogram equalizing filter", new FilterRHEF());
 
         public final String description;
         final Algorithm algorithm;
@@ -22,11 +26,16 @@ public class ImageFilter {
 
     interface Algorithm {
         float[] filter(float[] data, int width, int height);
+
+        // Radius-aware filters override this; the Sun-center region locates the annuli
+        default float[] filter(float[] data, int width, int height, @Nullable Region region) {
+            return filter(data, width, height);
+        }
     }
 
     private static final float BDIV = 1 / 255f;
 
-    private static byte[] filter(byte[] array, int width, int height, Algorithm algorithm) {
+    private static byte[] filter(byte[] array, int width, int height, Algorithm algorithm, @Nullable Region region) {
         int length = width * height;
 
         float[] data = new float[length];
@@ -40,7 +49,7 @@ public class ImageFilter {
             }
         });
 
-        float[] image = algorithm.filter(data, width, height);
+        float[] image = algorithm.filter(data, width, height, region);
 
         byte[] out = new byte[length];
         ParallelRange.run(height, (from, to) -> {
@@ -56,7 +65,7 @@ public class ImageFilter {
         return out;
     }
 
-    private static short[] filterHalfFloat(short[] array, int width, int height, Algorithm algorithm) {
+    private static short[] filterHalfFloat(short[] array, int width, int height, Algorithm algorithm, @Nullable Region region) {
         int length = width * height;
 
         float[] data = new float[length];
@@ -70,7 +79,7 @@ public class ImageFilter {
             }
         });
 
-        float[] image = algorithm.filter(data, width, height);
+        float[] image = algorithm.filter(data, width, height, region);
 
         short[] out = new short[length];
         ParallelRange.run(height, (from, to) -> {
@@ -86,12 +95,12 @@ public class ImageFilter {
         return out;
     }
 
-    static byte[] filter(byte[] data, int width, int height, Type type) {
-        return type == Type.None ? data : filter(data, width, height, type.algorithm);
+    static byte[] filter(byte[] data, int width, int height, Type type, @Nullable Region region) {
+        return type == Type.None ? data : filter(data, width, height, type.algorithm, region);
     }
 
-    static short[] filterHalfFloat(short[] data, int width, int height, Type type) {
-        return type == Type.None ? data : filterHalfFloat(data, width, height, type.algorithm);
+    static short[] filterHalfFloat(short[] data, int width, int height, Type type, @Nullable Region region) {
+        return type == Type.None ? data : filterHalfFloat(data, width, height, type.algorithm, region);
     }
 
 }

--- a/src/org/helioviewer/jhv/layers/ImageLayer.java
+++ b/src/org/helioviewer/jhv/layers/ImageLayer.java
@@ -211,7 +211,7 @@ public class ImageLayer extends AbstractLayer implements View.DataHandler {
 
         GLSLSolarShader shader = mv.mode().shader;
         shader.use();
-        glImage.applyFilters();
+        glImage.applyFilters(view.getFilter() == ImageFilter.Type.RHEF);
 
         MetaData meta0 = imageData.metaData();
         Position metaViewpoint0 = meta0.getViewpoint();

--- a/src/org/helioviewer/jhv/layers/filters/ImageFilterPanel.java
+++ b/src/org/helioviewer/jhv/layers/filters/ImageFilterPanel.java
@@ -2,12 +2,11 @@ package org.helioviewer.jhv.layers.filters;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
-import java.awt.FlowLayout;
+import java.awt.GridLayout;
 
-import javax.swing.ButtonGroup;
+import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JRadioButton;
 
 import org.helioviewer.jhv.display.DisplayController;
 import org.helioviewer.jhv.gui.component.Buttons;
@@ -19,7 +18,7 @@ import com.jidesoft.swing.JideSplitButton;
 
 public class ImageFilterPanel implements FilterDetails {
 
-    private final JPanel modePanel = new JPanel(new FlowLayout(FlowLayout.LEADING, 0, 0));
+    private final JComboBox<ImageFilter.Type> filterCombo = new JComboBox<>(ImageFilter.Type.values());
     private final JPanel buttonPanel = new JPanel(new BorderLayout());
     private final JLabel title = new JLabel("Filter ", JLabel.RIGHT);
 
@@ -27,21 +26,13 @@ public class ImageFilterPanel implements FilterDetails {
         return String.format("%.1f", value);
     }
 
+    private static String formatUpsilon(double value) {
+        return String.format("%.2f", value);
+    }
+
     public ImageFilterPanel(ImageLayer layer) {
-        ButtonGroup modeGroup = new ButtonGroup();
-        for (ImageFilter.Type type : ImageFilter.Type.values()) {
-            JRadioButton item = new JRadioButton(type.toString());
-            item.setToolTipText(type.description);
-            if (type == layer.getView().getFilter())
-                item.setSelected(true);
-            item.addActionListener(e -> {
-                layer.getView().clearCache();
-                layer.getView().setFilter(type);
-                DisplayController.render(1);
-            });
-            modeGroup.add(item);
-            modePanel.add(item);
-        }
+        filterCombo.setSelectedItem(layer.getView().getFilter());
+        filterCombo.setToolTipText(layer.getView().getFilter().description);
 
         JHVSlider slider = new JHVSlider(0, 30, (int) (layer.getGLImage().getEnhanced() * 10));
         JLabel label = new JLabel(formatLabel(slider.getValue() / 10.), JLabel.RIGHT);
@@ -61,6 +52,52 @@ public class ImageFilterPanel implements FilterDetails {
         enhanceButton.setAlwaysDropdown(true);
         enhanceButton.add(enhancePanel);
 
+        JHVSlider upsilonLowSlider = new JHVSlider(5, 100, (int) (layer.getGLImage().getUpsilonLow() * 100));
+        JLabel upsilonLowLabel = new JLabel(formatUpsilon(upsilonLowSlider.getValue() / 100.), JLabel.RIGHT);
+        upsilonLowSlider.addChangeListener(e -> {
+            double value = upsilonLowSlider.getValue() / 100.;
+            layer.getGLImage().setUpsilon(value, layer.getGLImage().getUpsilonHigh());
+            upsilonLowLabel.setText(formatUpsilon(value));
+            DisplayController.display();
+        });
+        JHVSlider upsilonHighSlider = new JHVSlider(5, 100, (int) (layer.getGLImage().getUpsilonHigh() * 100));
+        JLabel upsilonHighLabel = new JLabel(formatUpsilon(upsilonHighSlider.getValue() / 100.), JLabel.RIGHT);
+        upsilonHighSlider.addChangeListener(e -> {
+            double value = upsilonHighSlider.getValue() / 100.;
+            layer.getGLImage().setUpsilon(layer.getGLImage().getUpsilonLow(), value);
+            upsilonHighLabel.setText(formatUpsilon(value));
+            DisplayController.display();
+        });
+        JPanel upsilonLowRow = new JPanel(new BorderLayout());
+        upsilonLowRow.add(new JLabel("ΥL "), BorderLayout.LINE_START);
+        upsilonLowRow.add(upsilonLowSlider, BorderLayout.CENTER);
+        upsilonLowRow.add(upsilonLowLabel, BorderLayout.LINE_END);
+        JPanel upsilonHighRow = new JPanel(new BorderLayout());
+        upsilonHighRow.add(new JLabel("ΥH "), BorderLayout.LINE_START);
+        upsilonHighRow.add(upsilonHighSlider, BorderLayout.CENTER);
+        upsilonHighRow.add(upsilonHighLabel, BorderLayout.LINE_END);
+        JPanel upsilonPanel = new JPanel(new GridLayout(2, 1));
+        upsilonPanel.add(upsilonLowRow);
+        upsilonPanel.add(upsilonHighRow);
+
+        JideSplitButton upsilonButton = new JideSplitButton("Υ");
+        upsilonButton.setToolTipText("Soften shadows (ΥL, below median) and highlights (ΥH, above median) of RHEF output independently");
+        upsilonButton.setAlwaysDropdown(true);
+        upsilonButton.add(upsilonPanel);
+
+        // The Υ midtone control only affects RHEF, so enable it only when RHEF is selected.
+        upsilonButton.setEnabled(layer.getView().getFilter() == ImageFilter.Type.RHEF);
+        filterCombo.addActionListener(e -> {
+            if (filterCombo.getSelectedItem() instanceof ImageFilter.Type type && type != layer.getView().getFilter()) {
+                filterCombo.setToolTipText(type.description);
+                upsilonButton.setEnabled(type == ImageFilter.Type.RHEF);
+                layer.getView().clearCache();
+                layer.getView().setFilter(type);
+                DisplayController.render(1);
+            }
+        });
+
+        buttonPanel.add(upsilonButton, BorderLayout.LINE_START);
         buttonPanel.add(enhanceButton, BorderLayout.LINE_END);
     }
 
@@ -71,7 +108,7 @@ public class ImageFilterPanel implements FilterDetails {
 
     @Override
     public Component getSecond() {
-        return modePanel;
+        return filterCombo;
     }
 
     @Override

--- a/src/org/helioviewer/jhv/metadata/CommonMetaData.java
+++ b/src/org/helioviewer/jhv/metadata/CommonMetaData.java
@@ -21,6 +21,8 @@ class CommonMetaData implements MetaData {
     protected double unitPerPixelX = 1;
     protected double unitPerPixelY = 1;
     protected double unitPerArcsec = DEFAULT_UNIT_PER_ARCSEC;
+    protected double sunShiftX = 0;
+    protected double sunShiftY = 0;
     protected float responseFactor = 1;
 
     protected Position viewpoint = Sun.StartEarth;
@@ -121,6 +123,16 @@ class CommonMetaData implements MetaData {
     public Region roiToRegion(int roiX, int roiY, int roiWidth, int roiHeight, double factorX, double factorY) {
         return new Region(roiX * factorX * unitPerPixelX + region.llx, roiY * factorY * unitPerPixelY + region.lly,
                 roiWidth * factorX * unitPerPixelX, roiHeight * factorY * unitPerPixelY);
+    }
+
+    @Nonnull
+    @Override
+    public Region roiToSunRegion(int roiX, int roiY, int roiWidth, int roiHeight, double factorX, double factorY) {
+        Region r = roiToRegion(roiX, roiY, roiWidth, roiHeight, factorX, factorY);
+        if (sunShiftX == 0 && sunShiftY == 0)
+            return r;
+        // Move the origin from the WCS reference point to the Sun center
+        return new Region(r.llx - sunShiftX, r.lly + sunShiftY, r.width, r.height);
     }
 
     @Override

--- a/src/org/helioviewer/jhv/metadata/FitsMetaData.java
+++ b/src/org/helioviewer/jhv/metadata/FitsMetaData.java
@@ -10,6 +10,7 @@ import org.helioviewer.jhv.astronomy.Position;
 import org.helioviewer.jhv.astronomy.Sun;
 import org.helioviewer.jhv.math.Quat;
 import org.helioviewer.jhv.math.Vec2;
+import org.helioviewer.jhv.math.Vec3;
 import org.helioviewer.jhv.time.JHVTime;
 import org.helioviewer.jhv.wcs.WcsHeader;
 
@@ -295,6 +296,13 @@ public final class FitsMetaData extends CommonMetaData {
 
             if (!CROTABlockSet.contains(instrument))
                 crota = Quat.createAxisZ(wcs.crotaRad());
+
+            // Sun center in region coordinates, for radius-aware image filters
+            if (!isSurfaceMap && (crval.x != 0 || crval.y != 0)) {
+                Vec3 sun = crota.rotateInverseVector(new Vec3(-crval.x, -crval.y, 0));
+                sunShiftX = sun.x;
+                sunShiftY = sun.y;
+            }
         }
     }
 

--- a/src/org/helioviewer/jhv/metadata/MetaData.java
+++ b/src/org/helioviewer/jhv/metadata/MetaData.java
@@ -42,6 +42,9 @@ public interface MetaData {
     @Nonnull
     Region roiToRegion(int roiX, int roiY, int roiWidth, int roiHeight, double factorX, double factorY);
 
+    @Nonnull
+    Region roiToSunRegion(int roiX, int roiY, int roiWidth, int roiHeight, double factorX, double factorY);
+
     boolean getCalculateDepth();
 
     @Nonnull

--- a/src/org/helioviewer/jhv/opengl/GLImage.java
+++ b/src/org/helioviewer/jhv/opengl/GLImage.java
@@ -49,6 +49,13 @@ public class GLImage {
     private double blend = .5;
     private double sharpen = 0;
     private double enhanced = 0;
+    // RHEF two-sided midtone control (Upsilon), AIA 171 defaults (Gilly & DeForest 2024, §3.2,
+    // https://arxiv.org/html/2511.02798v1). The curve below the median (shadows, upsilonLow) and
+    // above it (highlights, upsilonHigh) are shaped independently, so the two handles are
+    // asymmetric by design. sunkit-image's rhef exposes the same split light/dark upsilon:
+    // https://docs.sunpy.org/projects/sunkit-image/en/stable/api/sunkit_image.radial.rhef.html
+    private double upsilonLow = .6;
+    private double upsilonHigh = .4;
     private DifferenceMode diffMode = DifferenceMode.None;
 
     private LUT lut = LUT.gray();
@@ -81,7 +88,7 @@ public class GLImage {
 
     private final float[] color = new float[4];
 
-    public void applyFilters() {
+    public void applyFilters(boolean rhefActive) {
         MetaData metaData = uploadedImageData.metaData();
         // shader.bindSector(gl, -Math.max(Math.abs(metaData.getSector0()), Math.abs(sector0)), Math.max(metaData.getSector1(), sector1));
         color[0] = (float) (opacity * red); // https://amindforeverprogramming.blogspot.com/2013/07/why-alpha-premultiplied-colour-blending.html
@@ -92,9 +99,14 @@ public class GLImage {
                 1f / uploadedImageData.imageBuffer().width, 1f / uploadedImageData.imageBuffer().height, (float) (-2 * sharpen), diffMode.ordinal(),
                 metaData.getSector0(), metaData.getSector1(), (float) enhanced,
                 metaData.getCutOffX(), metaData.getCutOffY(), metaData.getCutOffValue(), metaData.getCalculateDepth() ? 1 : 0,
-                (float) brightOffset, (float) (brightScale * metaData.getResponseFactor()),
+                // RHEF output is already a normalized rank in [0, 1]; the raw-DN response
+                // factor must NOT rescale it (that pushes the uniform upper half past 1 and
+                // clamps it to white). The user's Levels (brightOffset/brightScale) still
+                // apply as a black/white-point control on the equalized output.
+                (float) brightOffset, (float) (brightScale * (rhefActive ? 1 : metaData.getResponseFactor())),
                 Math.max(metaData.getInnerRadius(), (float) innerMask), Display.getShowCorona() ? metaData.getOuterRadius() : 1,
-                (float) slitLeft, (float) slitRight);
+                (float) slitLeft, (float) slitRight,
+                (float) (rhefActive ? upsilonLow : 1), (float) (rhefActive ? upsilonHigh : 1));
 
         applyLUT();
         applyMask(metaData.getDetectorMask());
@@ -263,6 +275,19 @@ public class GLImage {
         enhanced = Math.clamp(_enhanced, 0, 3);
     }
 
+    public void setUpsilon(double low, double high) {
+        upsilonLow = Math.clamp(low, 0.05, 1);
+        upsilonHigh = Math.clamp(high, 0.05, 1);
+    }
+
+    public double getUpsilonLow() {
+        return upsilonLow;
+    }
+
+    public double getUpsilonHigh() {
+        return upsilonHigh;
+    }
+
     public void setDifferenceMode(DifferenceMode mode) {
         diffMode = mode;
     }
@@ -312,6 +337,7 @@ public class GLImage {
         setInnerMask(jo.optDouble("innerMask", innerMask));
         setBrightness(jo.optDouble("brightOffset", brightOffset), jo.optDouble("brightScale", brightScale));
         setEnhanced(jo.optDouble("enhanced", enhanced));
+        setUpsilon(jo.optDouble("upsilonLow", upsilonLow), jo.optDouble("upsilonHigh", upsilonHigh));
         String strDiffMode = jo.optString("differenceMode", diffMode.toString());
         try {
             diffMode = DifferenceMode.valueOf(strDiffMode);
@@ -338,6 +364,8 @@ public class GLImage {
         jo.put("brightOffset", brightOffset);
         jo.put("brightScale", brightScale);
         jo.put("enhanced", enhanced);
+        jo.put("upsilonLow", upsilonLow);
+        jo.put("upsilonHigh", upsilonHigh);
         jo.put("differenceMode", diffMode);
 
         JSONObject colorObject = new JSONObject();

--- a/src/org/helioviewer/jhv/opengl/GLSLSolarShader.java
+++ b/src/org/helioviewer/jhv/opengl/GLSLSolarShader.java
@@ -158,13 +158,15 @@ public class GLSLSolarShader extends GLSLShader {
                             float cutOffX, float cutOffY, float cutOffVal, int calculateDepth,
                             float bOffset, float bScale,
                             float innerRadius, float outerRadius,
-                            float slitLeft, float slitRight) {
+                            float slitLeft, float slitRight,
+                            float upsilonLow, float upsilonHigh) {
         displayBuf.put(color);
         displayBuf.put(shWidth).put(shHeight).put(shWeight).put(isDiff);
         displayBuf.put(sector0).put(sector1).put(/*sector0 + 2 * Math.PI == sector1*/ sector0 == sector1 ? 0 : 1).put(enhanced);
         displayBuf.put(cutOffX).put(cutOffY).put(cutOffVal).put(calculateDepth);
         displayBuf.put(bOffset).put(bScale);
         displayBuf.put(innerRadius).put(outerRadius).put(slitLeft).put(slitRight);
+        displayBuf.put(upsilonLow).put(upsilonHigh);
 
         displayBuf.flip();
         displayBO.setBufferDataIfChanged(DISPLAY_SIZE, displayBuf);

--- a/src/org/helioviewer/jhv/view/j2k/J2KDecoder.java
+++ b/src/org/helioviewer/jhv/view/j2k/J2KDecoder.java
@@ -4,9 +4,12 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 
+import javax.annotation.Nullable;
+
 import org.helioviewer.jhv.app.Log;
 import org.helioviewer.jhv.image.ImageBuffer;
 import org.helioviewer.jhv.image.ImageFilter;
+import org.helioviewer.jhv.metadata.Region;
 
 import org.lwjgl.system.MemoryUtil;
 
@@ -24,7 +27,7 @@ import kdu_jni.Kdu_quality_limiter;
 import kdu_jni.Kdu_region_compositor;
 import kdu_jni.Kdu_thread_env;
 
-record J2KDecoder(J2KSource src, J2KParams.Decode params, int numComps, ImageFilter.Type filterType)
+record J2KDecoder(J2KSource src, J2KParams.Decode params, int numComps, ImageFilter.Type filterType, @Nullable Region region)
         implements Callable<ImageBuffer> {
 
     // Maximum of samples to process per rendering iteration
@@ -101,7 +104,7 @@ record J2KDecoder(J2KSource src, J2KParams.Decode params, int numComps, ImageFil
             boolean gray = numComps < 3;
             // Assume Kakadu's 4-byte compositor output already matches our RGBA byte upload layout.
             ImageBuffer.Format format = gray ? ImageBuffer.Format.Gray8 : ImageBuffer.Format.RGBA32;
-            ImageBuffer.WriteBuffer outBuffer = ImageBuffer.createWriteBuffer(actualWidth, actualHeight, format, filterType);
+            ImageBuffer.WriteBuffer outBuffer = ImageBuffer.createWriteBuffer(actualWidth, actualHeight, format, filterType, region);
             ByteBuffer outByteBuffer = outBuffer.byteBuffer();
 
             Kdu_dims newRegion = scratch.newRegion;

--- a/src/org/helioviewer/jhv/view/j2k/J2KView.java
+++ b/src/org/helioviewer/jhv/view/j2k/J2KView.java
@@ -293,10 +293,17 @@ public class J2KView extends BaseView {
         J2KDecodeKey key = new J2KDecodeKey(serial, decodeParams, filterType);
         int numComps = source.resolutionSet(decodeParams.frame).numComps;
         try {
-            executor.submit(new J2KDecoder(source, decodeParams, numComps, filterType), new J2KCallback(key, viewpoint, cacheResult));
+            executor.submit(new J2KDecoder(source, decodeParams, numComps, filterType, filterRegion(decodeParams)), new J2KCallback(key, viewpoint, cacheResult));
         } catch (RejectedExecutionException ignore) {
             // Teardown may shut the executor down before a late refresh/resubmit reaches this point.
         }
+    }
+
+    private Region filterRegion(J2KParams.Decode decodeParams) {
+        int frame = decodeParams.frame;
+        J2KParams.SubImage roi = decodeParams.subImage;
+        ResolutionSet.Level resolution = getResolutionLevel(frame, decodeParams.level);
+        return metaData[frame].roiToSunRegion(roi.x(), roi.y(), roi.w(), roi.h(), resolution.factorX(), resolution.factorY());
     }
 
     private class J2KCallback implements LatestWorker.Callback<ImageBuffer> {

--- a/src/org/helioviewer/jhv/view/uri/FITSImage.java
+++ b/src/org/helioviewer/jhv/view/uri/FITSImage.java
@@ -7,10 +7,13 @@ import java.nio.ByteBuffer;
 import java.nio.ShortBuffer;
 import java.util.Arrays;
 
+import javax.annotation.Nullable;
+
 import org.helioviewer.jhv.base.ArrayUtils;
 import org.helioviewer.jhv.image.ImageBuffer;
 import org.helioviewer.jhv.image.ImageFilter;
 import org.helioviewer.jhv.math.MathUtils;
+import org.helioviewer.jhv.metadata.Region;
 import org.helioviewer.jhv.thread.ParallelRange;
 
 import com.google.common.escape.Escaper;
@@ -34,20 +37,20 @@ public final class FITSImage implements URIImageReader {
     public URIImageReader.Image readImage(File file) throws Exception {
         try (Fits f = new Fits(file)) {
             BasicHDU<?> hdu = findHDU(f);
-            return new URIImageReader.Image(getHeaderAsXML(imageHeader(hdu)), readHDU(hdu, ImageFilter.Type.None), null);
+            return new URIImageReader.Image(getHeaderAsXML(imageHeader(hdu)), readHDU(hdu, ImageFilter.Type.None, null), null);
         }
     }
 
     @Override
-    public ImageBuffer readImageBuffer(File file, ImageFilter.Type filterType) throws Exception {
+    public ImageBuffer readImageBuffer(File file, ImageFilter.Type filterType, @Nullable Region region) throws Exception {
         try (Fits f = new Fits(file)) {
-            return readHDU(findHDU(f), filterType);
+            return readHDU(findHDU(f), filterType, region);
         }
     }
 
     public ImageBuffer readImageBuffer(InputStream input) throws Exception {
         try (Fits f = new Fits(input)) {
-            return readHDU(findHDU(f), ImageFilter.Type.None);
+            return readHDU(findHDU(f), ImageFilter.Type.None, null);
         }
     }
 
@@ -331,10 +334,10 @@ public final class FITSImage implements URIImageReader {
         return axes;
     }
 
-    private static ImageBuffer readHDU(BasicHDU<?> hdu, ImageFilter.Type filterType) throws Exception {
+    private static ImageBuffer readHDU(BasicHDU<?> hdu, ImageFilter.Type filterType, @Nullable Region region) throws Exception {
         Header header = imageHeader(hdu);
         int[] axes = imageAxes(header);
-        return readPixels(header, axes, readFlatPixels(hdu, axes), filterType);
+        return readPixels(header, axes, readFlatPixels(hdu, axes), filterType, region);
     }
 
     @SuppressWarnings("deprecation")
@@ -355,12 +358,12 @@ public final class FITSImage implements URIImageReader {
         return buffer.array();
     }
 
-    private static ImageBuffer readPixels(Header header, int[] axes, Object pixels, ImageFilter.Type filterType) throws Exception {
+    private static ImageBuffer readPixels(Header header, int[] axes, Object pixels, ImageFilter.Type filterType, @Nullable Region region) throws Exception {
         int height = axes[0];
         int width = axes[1];
 
         if (pixels instanceof byte[] inData) {
-            ImageBuffer.WriteBuffer outBuffer = ImageBuffer.createWriteBuffer(width, height, ImageBuffer.Format.Gray8, filterType);
+            ImageBuffer.WriteBuffer outBuffer = ImageBuffer.createWriteBuffer(width, height, ImageBuffer.Format.Gray8, filterType, region);
             ByteBuffer outData = outBuffer.byteBuffer();
             for (int j = 0; j < height; j++) {
                 outData.put(width * (height - 1 - j), inData, width * j, width);
@@ -386,7 +389,7 @@ public final class FITSImage implements URIImageReader {
                 SampleBuffer sampleData = sampleImage(pixels, hasBlank, blank, bzero, bscale, width, height);
                 int sampleLen = sampleData.length();
                 if (sampleLen < MIN_SAMPLES) // couldn't find enough acceptable samples, return blank image
-                    return ImageBuffer.createWriteBuffer(width, height, ImageBuffer.Format.Gray8, filterType).finish();
+                    return ImageBuffer.createWriteBuffer(width, height, ImageBuffer.Format.Gray8, filterType, region).finish();
 
                 if (state.clippingMode().percentile() > 0) {
                     double percentile = state.clippingMode().percentile();
@@ -408,7 +411,7 @@ public final class FITSImage implements URIImageReader {
         }
         // System.out.println(">>> " + min + ' ' + max);
 
-        ImageBuffer.WriteBuffer outBuffer = ImageBuffer.createWriteBuffer(width, height, ImageBuffer.Format.Gray16F, filterType);
+        ImageBuffer.WriteBuffer outBuffer = ImageBuffer.createWriteBuffer(width, height, ImageBuffer.Format.Gray16F, filterType, region);
         convertPixels(pixels, outBuffer.shortBuffer(), hasBlank, blank, bzero, bscale, width, height, min, max, state);
         return outBuffer.finish();
     }

--- a/src/org/helioviewer/jhv/view/uri/GenericImage.java
+++ b/src/org/helioviewer/jhv/view/uri/GenericImage.java
@@ -22,6 +22,7 @@ import org.helioviewer.jhv.image.ImageBuffer;
 import org.helioviewer.jhv.image.ImageFilter;
 import org.helioviewer.jhv.image.lut.LUT;
 import org.helioviewer.jhv.image.nio.NativeImageFactory;
+import org.helioviewer.jhv.metadata.Region;
 //import org.helioviewer.jhv.io.XMLUtils;
 
 // essentially static; local or network cache
@@ -69,15 +70,15 @@ final class GenericImage implements URIImageReader {
             */
             BufferedImage image = reader.read(0);
             LUT lut = readLUT(image);
-            ImageBuffer imageBuffer = readBuffered(image, ImageFilter.Type.None);
+            ImageBuffer imageBuffer = readBuffered(image, ImageFilter.Type.None, null);
 
             return new URIImageReader.Image(xml, imageBuffer, lut);
         });
     }
 
     @Override
-    public ImageBuffer readImageBuffer(File file, ImageFilter.Type filterType) throws Exception {
-        return withReader(file, reader -> readBuffered(reader.read(0), filterType));
+    public ImageBuffer readImageBuffer(File file, ImageFilter.Type filterType, @Nullable Region region) throws Exception {
+        return withReader(file, reader -> readBuffered(reader.read(0), filterType, region));
     }
 
     @Nullable
@@ -98,18 +99,18 @@ final class GenericImage implements URIImageReader {
         }
     }
 
-    private static ImageBuffer readBuffered(BufferedImage image, ImageFilter.Type filterType) {
+    private static ImageBuffer readBuffered(BufferedImage image, ImageFilter.Type filterType, @Nullable Region region) {
         int w = image.getWidth();
         int h = image.getHeight();
 
         switch (image.getType()) {
             case BufferedImage.TYPE_BYTE_GRAY, BufferedImage.TYPE_BYTE_INDEXED -> {
                 return ImageBuffer.fromBytes(w, h, ImageBuffer.Format.Gray8,
-                        ((DataBufferByte) image.getRaster().getDataBuffer()).getData(), filterType);
+                        ((DataBufferByte) image.getRaster().getDataBuffer()).getData(), filterType, region);
             }
             case BufferedImage.TYPE_USHORT_GRAY -> {
                 return ImageBuffer.fromShorts(w, h, ImageBuffer.Format.Gray16F,
-                        halfFloat(((DataBufferUShort) image.getRaster().getDataBuffer()).getData()), filterType);
+                        halfFloat(((DataBufferUShort) image.getRaster().getDataBuffer()).getData()), filterType, region);
             }
             default -> {
                 BufferedImage conv = NativeImageFactory.createRGBAPremultipliedImage(w, h);

--- a/src/org/helioviewer/jhv/view/uri/URIImageReader.java
+++ b/src/org/helioviewer/jhv/view/uri/URIImageReader.java
@@ -7,6 +7,7 @@ import javax.annotation.Nullable;
 import org.helioviewer.jhv.image.ImageBuffer;
 import org.helioviewer.jhv.image.ImageFilter;
 import org.helioviewer.jhv.image.lut.LUT;
+import org.helioviewer.jhv.metadata.Region;
 
 interface URIImageReader {
 
@@ -14,6 +15,6 @@ interface URIImageReader {
 
     Image readImage(File file) throws Exception;
 
-    ImageBuffer readImageBuffer(File file, ImageFilter.Type filterType) throws Exception;
+    ImageBuffer readImageBuffer(File file, ImageFilter.Type filterType, @Nullable Region region) throws Exception;
 
 }

--- a/src/org/helioviewer/jhv/view/uri/URIView.java
+++ b/src/org/helioviewer/jhv/view/uri/URIView.java
@@ -31,6 +31,7 @@ public final class URIView extends BaseView {
     private final URIImageReader reader;
     private final String xml;
     private final Region imageRegion;
+    private final Region filterRegion;
 
     public URIView(LatestWorker<ImageBuffer> _executor, DataUri _dataUri) throws Exception {
         super(_executor, _dataUri);
@@ -55,6 +56,7 @@ public final class URIView extends BaseView {
             xml = readXml;
 
             imageRegion = m.roiToRegion(0, 0, buffer.width, buffer.height, 1, 1);
+            filterRegion = m.roiToSunRegion(0, 0, buffer.width, buffer.height, 1, 1);
             metaData[0] = m;
             ImageBufferCache.put(decodeKey(ImageFilter.Type.None), buffer);
 
@@ -76,7 +78,7 @@ public final class URIView extends BaseView {
             sendDataToHandler(imageBuffer, viewpoint);
             return;
         }
-        executor.submit(new Decoder(dataUri.file(), reader, filterType), new Callback(key, viewpoint));
+        executor.submit(new Decoder(dataUri.file(), reader, filterType, filterRegion), new Callback(key, viewpoint));
     }
 
     private ImageFilter.Type decodeKeyFilter;
@@ -90,11 +92,11 @@ public final class URIView extends BaseView {
         return decodeKey;
     }
 
-    private record Decoder(File file, URIImageReader reader, ImageFilter.Type type) implements Callable<ImageBuffer> {
+    private record Decoder(File file, URIImageReader reader, ImageFilter.Type type, Region region) implements Callable<ImageBuffer> {
         @Nonnull
         @Override
         public ImageBuffer call() throws Exception {
-            ImageBuffer imageBuffer = reader.readImageBuffer(file, type);
+            ImageBuffer imageBuffer = reader.readImageBuffer(file, type, region);
             if (imageBuffer == null) // e.g. FITS
                 throw new Exception("Could not read: " + file);
             return imageBuffer;


### PR DESCRIPTION
## Motivation
RHEF is a coronal-enhancement filter that rank-equalizes pixels within
radial annuli centered on the Sun ([Gilly & DeForest 2024](https://arxiv.org/html/2511.02798v1);
[sunkit-image `radial.rhef`](https://docs.sunpy.org/projects/sunkit-image/en/stable/api/sunkit_image.radial.rhef.html)).
Unlike the spatially-local MGN and WOW filters already in JHV, it normalizes per-radius, which
flattens the steep radial brightness falloff of the corona and reveals faint outer structure
(streamers, CME fronts) without manual tuning. It applies to any Sun-centered imagery —
SDO/AIA, SWAP, LASCO, PUNCH.

## What this adds
- A new `ImageFilter.Type.RHEF` filter (decode-time, CPU), implemented with a
  sort-and-group rank kernel so cost does not scale with annulus count.
- An **Upsilon** midtone control implementing the paper's two-parameter redistribution
  ([§3.2, Eq. 2](https://arxiv.org/html/2511.02798v1)): `Υ_L` shapes intensities below the
  median, `Υ_H` above. The two handles are **asymmetric by design** — softening shadows and
  highlights independently is the point of the control, not redundant tuning; sunkit-image's
  `rhef` exposes the same split light/dark upsilon
  ([implementation](https://docs.sunpy.org/projects/sunkit-image/en/stable/_modules/sunkit_image/radial.html#rhef)).
  Two independent sliders (each 0.05–1), defaulting to the AIA-171 recommendation
  `Υ_L=0.60, Υ_H=0.40` (Fig. 3), so RHEF looks right out of the box instead of blown out.
  Applied at render time in `solarCommon.frag` (instant slider response) and **gated to the
  RHEF filter only** — for None/MGN/WOW the layer passes `Υ=1`, so their rendering is untouched.

## How it works
RHEF must know where the Sun is and the pixel scale to define its annuli, but JHV filters
a dynamically-decoded ROI sub-image, so "assume image center" is wrong under pan/zoom.
This PR threads a minimal `@Nullable Region` (the same `roiToRegion` output the decode path
already computes) to the filter so the kernel can center its annuli correctly, including
for off-center (nonzero `CRVAL`) sources. MGN/WOW ignore the new argument (default method),
so their behavior is unchanged.

## Files
- `image/FilterRHEF.java` (new) — the rank kernel + upsilon math
- `image/ImageFilter.java` — `RHEF` enum entry; `Region` threaded into the dispatch
- `image/ImageBuffer.java`, `view/j2k/{J2KView,J2KDecoder}.java`,
  `view/uri/{URIView,URIImageReader,FITSImage,GenericImage}.java` — carry the Region to the
  filter (one-line plumbing each)
- `metadata/{MetaData,CommonMetaData,FitsMetaData}.java` — `roiToSunRegion` accessor
- `opengl/{GLImage,GLSLSolarShader}.java`, `resources/glsl/solarCommon.frag`,
  `layers/filters/ImageFilterPanel.java` — render-time upsilon + its slider; the filter
  selector is changed from radio buttons to a `JComboBox` (a 4th filter overflows the row's
  width as radios)

## Testing
Builds clean (`ant compile`). Smoke-tested in-app on macOS / ANGLE-Metal: RHEF equalizes the
corona correctly, the ΥL / ΥH sliders give independent, smooth control over shadow and
highlight midtones, and the Υ control is correctly gated (enabled only for RHEF). **Reviewer
note:** two items are worth a confirming look on other platforms that I can't cover here —
(1) the `std140` packing of the new `upsilon` field into the `Display` UBO block, and (2) the
off-center-Sun (nonzero `CRVAL`) annulus-centering Y-sign. Both are isolated.

## Open questions for the maintainer
- Is it acceptable to widen `ImageFilter.Algorithm` so filters receive a `@Nullable Region`
  (Sun-center + scale)? This is the minimal way to give a radial filter geometry; MGN/WOW
  are untouched.
- Adding a 4th filter overflowed the radio-button row, so the filter selector is now a
  `JComboBox`. Prefer that, or keep radio buttons (wrapped to two lines)?
- The default `Υ_L=0.60, Υ_H=0.40` is the AIA-171 row of Fig. 3, applied to every layer.
  Worth keying the default off the layer's wavelength (full Fig. 3 table) instead of one
  representative pair?

## References
- Gilly & DeForest 2024, *Radial Histogram Equalizing Filter*, §3.2: https://arxiv.org/html/2511.02798v1
- sunkit-image `radial.rhef` API (split light/dark `upsilon`): https://docs.sunpy.org/projects/sunkit-image/en/stable/api/sunkit_image.radial.rhef.html
- sunkit-image `rhef` source: https://docs.sunpy.org/projects/sunkit-image/en/stable/_modules/sunkit_image/radial.html#rhef
- sunkit-image RHEF gallery example: https://docs.sunpy.org/projects/sunkit-image/en/stable/generated/gallery/radial_histogram_equalization.html
