### PR TITLE
Add a New PUNCH Layer source (PUNCH SDAC archive) with the PUNCH colormap default

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 - Improve thick-line joins, rectangle corners, annotation loops, and FOV outline rendering
 - Improve flat-grid stability and grid label formatting
 - Adjust trajectory colors for white canvas (fixes #260)
+- Add a `New PUNCH Layer` source that loads FITS frames from the PUNCH archive at `umbra.nascom.nasa.gov/punch`
 
 ### Timeline, events, and UI
 - Map HEK Flare Trigger events to Flare events (fixes #105)

--- a/resources/settings/colors.js
+++ b/resources/settings/colors.js
@@ -156,6 +156,8 @@
   "color":"PUNCH"},
  {"instrument":"NFI-0",
   "color":"PUNCH"},
+ {"instrument":"WFI+NFI Mosaic",
+  "color":"PUNCH"},
 
 ]
 

--- a/src/org/helioviewer/jhv/gui/Actions.java
+++ b/src/org/helioviewer/jhv/gui/Actions.java
@@ -22,6 +22,7 @@ import org.helioviewer.jhv.display.DisplayController;
 import org.helioviewer.jhv.gui.dialog.LoadStateDialog;
 import org.helioviewer.jhv.gui.dialog.NewVersionDialog;
 import org.helioviewer.jhv.gui.dialog.ObservationDialog;
+import org.helioviewer.jhv.gui.dialog.PunchDialog;
 import org.helioviewer.jhv.gui.dialog.SoarDialog;
 import org.helioviewer.jhv.gui.dialog.SynopticDialog;
 import org.helioviewer.jhv.io.DataSources;
@@ -112,6 +113,17 @@ public final class Actions {
         @Override
         public void actionPerformed(ActionEvent e) {
             SynopticDialog.getInstance().showDialog();
+        }
+    }
+
+    public static class NewPunchLayer extends AbstractAction {
+        public NewPunchLayer() {
+            super("New PUNCH Layer...");
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            PunchDialog.getInstance().showDialog();
         }
     }
 

--- a/src/org/helioviewer/jhv/gui/component/MenuBar.java
+++ b/src/org/helioviewer/jhv/gui/component/MenuBar.java
@@ -27,6 +27,7 @@ public final class MenuBar extends JMenuBar {
         fileMenu.add(new Actions.NewLayer());
         fileMenu.add(new Actions.NewSoarLayer());
         fileMenu.add(new Actions.NewSynopticLayer());
+        fileMenu.add(new Actions.NewPunchLayer());
         fileMenu.add(new Actions.OpenLocalFile());
         fileMenu.addSeparator();
         fileMenu.add(new Actions.LoadState());

--- a/src/org/helioviewer/jhv/gui/dialog/PunchDialog.java
+++ b/src/org/helioviewer/jhv/gui/dialog/PunchDialog.java
@@ -1,0 +1,281 @@
+package org.helioviewer.jhv.gui.dialog;
+
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.event.ActionEvent;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+import javax.swing.AbstractAction;
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+
+import org.helioviewer.jhv.app.Message;
+import org.helioviewer.jhv.gui.MainFrame;
+import org.helioviewer.jhv.gui.time.TimeSelectorPanel;
+import org.helioviewer.jhv.io.APIRequest;
+import org.helioviewer.jhv.io.PunchClient;
+import org.helioviewer.jhv.layers.ImageLayer;
+import org.helioviewer.jhv.layers.Layers;
+import org.helioviewer.jhv.movie.Player;
+import org.helioviewer.jhv.time.TimeUtils;
+
+import com.jidesoft.dialog.ButtonPanel;
+import com.jidesoft.dialog.StandardDialog;
+
+@SuppressWarnings("serial")
+public class PunchDialog extends StandardDialog implements PunchClient.ReceiverItems, PunchClient.ReceiverProducts, PunchClient.ReceiverCoverage {
+
+    // Generous cap with a confirmation prompt past CONFIRM_FILES; downloads happen
+    // serially under Commands.loadImage, so the layer is usable as frames stream in
+    private static final int MAX_FILES = 5000;
+    private static final int CONFIRM_FILES = 200;
+    private static final Dimension resultSize = new Dimension(500, 350);
+    private static final String[] Level = {"3", "Q", "2", "1", "0"};
+    private static final Map<String, String> ProductInfo = Map.ofEntries(
+            Map.entry("PTM", "polarized trefoil mosaic (high cadence)"),
+            Map.entry("CTM", "clear trefoil mosaic (high cadence)"),
+            Map.entry("PAM", "polarized average / low-noise mosaic"),
+            Map.entry("CAM", "clear average / low-noise mosaic"),
+            Map.entry("PNN", "polarized NFI image"),
+            Map.entry("CNN", "clear NFI image"),
+            Map.entry("PFM", "polarized F-corona mosaic"),
+            Map.entry("CFM", "clear F-corona mosaic"),
+            Map.entry("PIM", "polarized instrumental mosaic"),
+            Map.entry("CIM", "clear instrumental mosaic"),
+            Map.entry("PSM", "polarized starfield mosaic"),
+            Map.entry("CSM", "clear starfield mosaic"),
+            Map.entry("CQM", "quickPUNCH clear mosaic"));
+
+    private record Cadence(String label, long milli) {
+        @Override
+        public String toString() {
+            return label;
+        }
+    }
+
+    private static final Cadence[] Cadences = {
+            new Cadence("native cadence", 0),
+            new Cadence("every 10 minutes", 10 * 60_000L),
+            new Cadence("every 30 minutes", 30 * 60_000L),
+            new Cadence("every hour", 3600_000L),
+            new Cadence("every 3 hours", 3 * 3600_000L),
+            new Cadence("every 6 hours", 6 * 3600_000L),
+            new Cadence("every day", 24 * 3600_000L)};
+
+    private final JComboBox<String> levelCombo = new JComboBox<>(Level);
+    private final JComboBox<String> productCombo = new JComboBox<>();
+    private final JComboBox<Cadence> cadenceCombo = new JComboBox<>(Cadences);
+    private final TimeSelectorPanel timeSelectorPanel = new TimeSelectorPanel();
+    private final JList<PunchClient.DataItem> listPane = new JList<>();
+    private final JLabel foundLabel = new JLabel("0 found", JLabel.RIGHT);
+    private final JLabel coverageLabel = new JLabel(" ", JLabel.LEFT);
+
+    private boolean productsDownloaded;
+    private boolean rangeUserChanged; // true once the user has explicitly set a range
+
+    private static PunchDialog instance;
+
+    public static PunchDialog getInstance() {
+        return instance == null ? instance = new PunchDialog(MainFrame.get()) : instance;
+    }
+
+    private PunchDialog(JFrame mainFrame) {
+        super(mainFrame, true);
+        setResizable(false);
+        setTitle("New PUNCH Layer");
+    }
+
+    @Override
+    public ButtonPanel createButtonPanel() {
+        AbstractAction close = new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                setVisible(false);
+            }
+        };
+        setDefaultCancelAction(close);
+
+        JButton loadButton = getLoadButton();
+        JButton cancelButton = new JButton(close);
+        cancelButton.setText("Cancel");
+
+        ButtonPanel panel = new ButtonPanel();
+        panel.add(loadButton, ButtonPanel.AFFIRMATIVE_BUTTON);
+        panel.add(cancelButton, ButtonPanel.CANCEL_BUTTON);
+
+        return panel;
+    }
+
+    private JButton getLoadButton() {
+        JButton loadButton = new JButton("Add");
+        loadButton.addActionListener(e -> {
+            List<PunchClient.DataItem> items = listPane.getSelectedValuesList();
+            if (items.isEmpty())
+                return;
+
+            if (items.size() > MAX_FILES) {
+                Message.err("PUNCH error", String.format("Too many files selected for download: %d.%nPlease reduce the selection to less than %d files or choose a sparser cadence.", items.size(), MAX_FILES));
+                return;
+            }
+            if (items.size() > CONFIRM_FILES) {
+                int choice = JOptionPane.showConfirmDialog(this,
+                        String.format("This will download %d native-resolution FITS files (typically a few MB each).%nThey are fetched one after the other so the layer is usable as frames stream in.%nProceed?", items.size()),
+                        "Large PUNCH download", JOptionPane.OK_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE);
+                if (choice != JOptionPane.OK_OPTION)
+                    return;
+            }
+            PunchClient.submitLoad(items);
+            setVisible(false);
+        });
+        return loadButton;
+    }
+
+    @Override
+    public JComponent createContentPanel() {
+        JPanel dataSelector = new JPanel(new FlowLayout(FlowLayout.TRAILING, 5, 0));
+        dataSelector.add(new JLabel("Level", JLabel.RIGHT));
+        dataSelector.add(levelCombo);
+        dataSelector.add(productCombo);
+        dataSelector.add(cadenceCombo);
+        JButton searchButton = getSearchButton();
+        dataSelector.add(searchButton);
+
+        levelCombo.addActionListener(e -> {
+            if (levelCombo.getSelectedItem() instanceof String level)
+                PunchClient.submitGetProducts(this, level);
+        });
+        productCombo.addActionListener(e -> {
+            if (productCombo.getSelectedItem() instanceof String product)
+                productCombo.setToolTipText(ProductInfo.getOrDefault(product, "PUNCH data product"));
+        });
+
+        JPanel foundPanel = new JPanel(new FlowLayout(FlowLayout.TRAILING, 5, 0));
+        foundPanel.add(foundLabel);
+        JPanel selectedPanel = new JPanel(new FlowLayout(FlowLayout.TRAILING, 5, 0));
+        JLabel selectedLabel = new JLabel("0 selected", JLabel.RIGHT);
+        selectedPanel.add(selectedLabel);
+
+        listPane.addListSelectionListener(e -> {
+            if (!e.getValueIsAdjusting())
+                selectedLabel.setText(listPane.getSelectedValuesList().size() + " selected");
+        });
+        com.jidesoft.swing.SearchableUtils.installSearchable(listPane);
+        JScrollPane scrollPane = new JScrollPane(listPane);
+        scrollPane.setPreferredSize(resultSize);
+
+        // Any explicit edit to the time fields counts as "user-set", so we stop
+        // overwriting on the next coverage probe
+        timeSelectorPanel.addListener((start, end) -> rangeUserChanged = true);
+
+        JPanel content = new JPanel();
+        content.setLayout(new BoxLayout(content, BoxLayout.PAGE_AXIS));
+        content.add(timeSelectorPanel);
+        content.add(dataSelector);
+        JPanel coveragePanel = new JPanel(new FlowLayout(FlowLayout.LEADING, 5, 0));
+        coveragePanel.add(coverageLabel);
+        content.add(coveragePanel);
+        content.add(foundPanel);
+        content.add(scrollPane);
+        content.add(selectedPanel);
+
+        content.setBorder(BorderFactory.createEmptyBorder(3, 3, 3, 3));
+        return content;
+    }
+
+    private JButton getSearchButton() {
+        JButton searchButton = new JButton("Search");
+        searchButton.addActionListener(e -> {
+            if (levelCombo.getSelectedItem() instanceof String level && productCombo.getSelectedItem() instanceof String product &&
+                    cadenceCombo.getSelectedItem() instanceof Cadence cadence) {
+                PunchClient.submitSearchTime(this, level, product, timeSelectorPanel.getStartTime(), timeSelectorPanel.getEndTime(), cadence.milli);
+                foundLabel.setText("Searching...");
+            }
+        });
+        return searchButton;
+    }
+
+    @Nullable
+    @Override
+    public JComponent createBannerPanel() {
+        return null;
+    }
+
+    public void showDialog() {
+        if (!productsDownloaded && levelCombo.getSelectedItem() instanceof String level)
+            PunchClient.submitGetProducts(this, level);
+
+        // Inherit the main-window time range so the user does not retype it: prefer the
+        // active image layer's request range (what the main New Layer dialog shows), and
+        // fall back to the movie span. If nothing is loaded, the time selector defaults to
+        // "now", which is past the public archive's coverage for PUNCH; the coverage probe
+        // below fixes that by setting the range to the archive's latest day.
+        long start = Player.getStartTime();
+        long end = Player.getEndTime();
+        ImageLayer active = Layers.getActiveImageLayer();
+        APIRequest req;
+        if (active != null && (req = active.getView().getAPIRequest()) != null) {
+            start = req.startTime();
+            end = req.endTime();
+        }
+        if (start > TimeUtils.START.milli && end > start) {
+            timeSelectorPanel.setTime(start, end);
+            rangeUserChanged = true; // honor the range even if coverage comes back later
+        }
+        coverageLabel.setText("Checking archive coverage...");
+        if (levelCombo.getSelectedItem() instanceof String level && productCombo.getSelectedItem() instanceof String product)
+            PunchClient.submitGetCoverage(this, level, product);
+
+        pack();
+        setLocationRelativeTo(MainFrame.get());
+        setVisible(true);
+    }
+
+    @Override
+    public void setPunchResponseItems(List<PunchClient.DataItem> list) {
+        listPane.setListData(list.toArray(PunchClient.DataItem[]::new));
+        foundLabel.setText(list.isEmpty()
+                ? "0 found — archive may not cover this period; see umbra.nascom.nasa.gov/punch"
+                : list.size() + " found");
+    }
+
+    @Override
+    public void setPunchResponseProducts(List<String> list) {
+        productCombo.setModel(new DefaultComboBoxModel<>(list.toArray(String[]::new)));
+        productsDownloaded = true; // mark loaded only after successful callback
+        if (list.contains("CAM"))
+            productCombo.setSelectedItem("CAM");
+        else if (!list.isEmpty())
+            productCombo.setSelectedIndex(0);
+        // Now that we know the product, kick off the coverage probe
+        if (levelCombo.getSelectedItem() instanceof String level && productCombo.getSelectedItem() instanceof String product)
+            PunchClient.submitGetCoverage(this, level, product);
+    }
+
+    @Override
+    public void setPunchResponseCoverage(long latestDayMilli) {
+        if (latestDayMilli == 0) {
+            coverageLabel.setText("Archive: no data for this product");
+            return;
+        }
+        coverageLabel.setText("Archive: latest day available is " + TimeUtils.format(latestDayMilli).substring(0, 10));
+        if (!rangeUserChanged) {
+            // Default to the latest archived day (00:00 -> 24:00 UTC). The user can edit
+            // and the next probe will not overwrite their choice.
+            timeSelectorPanel.setTime(latestDayMilli, latestDayMilli + TimeUtils.DAY_IN_MILLIS - 1);
+            rangeUserChanged = false; // setTime fires the listener and flips this — undo
+        }
+    }
+
+}

--- a/src/org/helioviewer/jhv/io/PunchClient.java
+++ b/src/org/helioviewer/jhv/io/PunchClient.java
@@ -1,0 +1,164 @@
+package org.helioviewer.jhv.io;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.concurrent.Callable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nonnull;
+
+import org.helioviewer.jhv.app.Commands;
+import org.helioviewer.jhv.app.Log;
+import org.helioviewer.jhv.thread.Task;
+import org.helioviewer.jhv.time.TimeUtils;
+
+// Lists and loads native FITS files from the PUNCH archive at the Solar Data
+// Analysis Center (public, no auth). The archive is a plain directory tree:
+// {BASE}/{level}/{product}/{YYYY}/{MM}/{DD}/PUNCH_L{lvl}_{code}_{YYYYMMDDhhmmss}_v{ver}.fits
+public final class PunchClient {
+
+    private static final String BASE_URL = "https://umbra.nascom.nasa.gov/punch";
+    private static final Pattern FILE_PATTERN = Pattern.compile("PUNCH_L[0-9A-Z]_[A-Z0-9]{3}_(\\d{14})_v[0-9A-Za-z]+\\.fits");
+    private static final Pattern DIR_PATTERN = Pattern.compile("href=\"([A-Z0-9]{2,4})/\"");
+    private static final Pattern NUM_DIR_PATTERN = Pattern.compile("href=\"(\\d{2,4})/\"");
+    private static final DateTimeFormatter FILE_TIME = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+    public record DataItem(String file, URI uri, long milli) {
+        @Override
+        public String toString() {
+            return TimeUtils.format(milli) + "  " + file;
+        }
+    }
+
+    public interface ReceiverItems {
+        void setPunchResponseItems(List<DataItem> list);
+    }
+
+    public interface ReceiverProducts {
+        void setPunchResponseProducts(List<String> list);
+    }
+
+    public interface ReceiverCoverage {
+        // Latest day with data, in UTC epoch ms; 0 if the archive has nothing for this product
+        void setPunchResponseCoverage(long latestDayMilli);
+    }
+
+    public static void submitSearchTime(@Nonnull ReceiverItems receiver, @Nonnull String level, @Nonnull String product, long start, long end, long cadence) {
+        Task.submit("punch", new QueryItems(level, product, start, end, cadence), receiver::setPunchResponseItems, "Error listing the PUNCH archive");
+    }
+
+    public static void submitGetProducts(@Nonnull ReceiverProducts receiver, @Nonnull String level) {
+        Task.submit("punch", new QueryProducts(level), receiver::setPunchResponseProducts, "Error listing the PUNCH archive");
+    }
+
+    public static void submitGetCoverage(@Nonnull ReceiverCoverage receiver, @Nonnull String level, @Nonnull String product) {
+        Task.submit("punch", new QueryCoverage(level, product), receiver::setPunchResponseCoverage, "Error listing the PUNCH archive");
+    }
+
+    public static void submitLoad(@Nonnull List<DataItem> items) {
+        Commands.loadImage(items.stream().map(DataItem::uri).toList());
+    }
+
+    private static String readIndex(String url) throws Exception {
+        try (NetClient nc = NetClient.of(new URI(url), true, NetClient.NetCache.NETWORK)) {
+            boolean ok = nc.isSuccessful();
+            String body = ok ? nc.getSource().readUtf8() : null;
+            Log.info("PUNCH " + url + " -> " + (ok ? body.length() + " bytes" : "not ok"));
+            return body;
+        }
+    }
+
+    private record QueryProducts(String level) implements Callable<List<String>> {
+        @Override
+        public List<String> call() throws Exception {
+            String html = readIndex(BASE_URL + '/' + level + '/');
+            List<String> products = new ArrayList<>();
+            if (html != null) {
+                Matcher m = DIR_PATTERN.matcher(html);
+                while (m.find())
+                    products.add(m.group(1));
+            }
+            return products;
+        }
+    }
+
+    private record QueryCoverage(String level, String product) implements Callable<Long> {
+        @Override
+        public Long call() throws Exception {
+            // Walk year -> month -> day, picking the lexicographically largest at each level
+            String latestYear = latestNumeric(BASE_URL + '/' + level + '/' + product + '/');
+            if (latestYear == null)
+                return 0L;
+            String latestMonth = latestNumeric(BASE_URL + '/' + level + '/' + product + '/' + latestYear + '/');
+            if (latestMonth == null)
+                return 0L;
+            String latestDay = latestNumeric(BASE_URL + '/' + level + '/' + product + '/' + latestYear + '/' + latestMonth + '/');
+            if (latestDay == null)
+                return 0L;
+            return LocalDateTime.of(Integer.parseInt(latestYear), Integer.parseInt(latestMonth), Integer.parseInt(latestDay), 0, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+        }
+
+        private static String latestNumeric(String url) throws Exception {
+            String html = readIndex(url);
+            if (html == null)
+                return null;
+            String latest = null;
+            Matcher m = NUM_DIR_PATTERN.matcher(html);
+            while (m.find()) {
+                String s = m.group(1);
+                if (latest == null || s.compareTo(latest) > 0)
+                    latest = s;
+            }
+            return latest;
+        }
+    }
+
+    private record QueryItems(String level, String product, long start, long end, long cadence) implements Callable<List<DataItem>> {
+        @Override
+        public List<DataItem> call() throws Exception {
+            // Newer versions of the same timestamp overwrite older ones (index is name-sorted)
+            TreeMap<Long, DataItem> found = new TreeMap<>();
+            for (long day = Math.floorDiv(start, TimeUtils.DAY_IN_MILLIS) * TimeUtils.DAY_IN_MILLIS; day <= end; day += TimeUtils.DAY_IN_MILLIS)
+                listDay(found, day);
+
+            // lastKept is seeded just below the first possible in-range item so that any
+            // item with milli >= start passes the cadence check on the first iteration.
+            // Using Long.MIN_VALUE here would overflow the (item.milli - lastKept) check.
+            List<DataItem> result = new ArrayList<>(found.size());
+            long lastKept = start - Math.max(1, cadence) - 1;
+            for (DataItem item : found.values()) {
+                if (item.milli >= start && item.milli <= end && item.milli - lastKept >= cadence) {
+                    result.add(item);
+                    lastKept = item.milli;
+                }
+            }
+            return result;
+        }
+
+        private void listDay(TreeMap<Long, DataItem> found, long day) throws Exception {
+            LocalDateTime date = LocalDateTime.ofEpochSecond(day / 1000, 0, ZoneOffset.UTC);
+            String dirUrl = String.format("%s/%s/%s/%04d/%02d/%02d/", BASE_URL, level, product, date.getYear(), date.getMonthValue(), date.getDayOfMonth());
+            String html = readIndex(dirUrl);
+            if (html == null)
+                return;
+
+            int matched = 0;
+            Matcher m = FILE_PATTERN.matcher(html);
+            while (m.find()) {
+                String file = m.group();
+                long milli = LocalDateTime.parse(m.group(1), FILE_TIME).toInstant(ZoneOffset.UTC).toEpochMilli();
+                found.put(milli, new DataItem(file, URI.create(dirUrl + file), milli));
+                matched++;
+            }
+            Log.info("PUNCH parsed " + matched + " files from " + dirUrl);
+        }
+    }
+
+    private PunchClient() {}
+}


### PR DESCRIPTION
## Motivation
[NASA PUNCH](https://punch.space.swri.edu/) (launched 2025) images the inner heliosphere in
white light — a coronagraph/heliospheric-imager mosaic that extends the AIA→K-Cor→LASCO→CCOR
ladder out past 20 R☉. Its calibrated data lives in a public archive at the SDAC
(`umbra.nascom.nasa.gov/punch`), but JHV has no way to load it. This adds a source for it.

## What this adds (commit 1 — the source)
- **`File > New PUNCH Layer…`** dialog that browses the public PUNCH archive (no auth) and loads
  native FITS frames as a movie layer.
  - **Level / Product / Cadence** selectors. Products are discovered live from the archive
    (PTM/CTM trefoil mosaics, PAM/CAM low-noise mosaics, NFI/F-corona/starfield, quickPUNCH…),
    with tooltips.
  - An **archive-coverage probe** fills the time range to the latest available day, so you don't
    land on an empty "now" (the public archive lags real time).
  - **Cadence thinning** (native / 10 min / hourly / …) and a large-selection confirmation prompt.
  - The archive is a plain dated directory tree; `PunchClient` lists/parses it with no extra deps.

## Commit 2 — PUNCH colormap default
The bundled `PUNCH` color table already exists, and `colors.js` already maps PUNCH's *per-spacecraft*
instruments (`WFI-1..3`, `NFI-0`) to it — but the **mosaic** products served from the archive
(CAM/PAM/CTM/PTM) report `INSTRUME='WFI+NFI Mosaic'`, which matched no rule, so they loaded gray.
This adds one rule for that instrument so loaded PUNCH mosaics get the PUNCH table by default
(verified against real archive headers).

## Files
- `gui/dialog/PunchDialog.java` (new), `io/PunchClient.java` (new) — the dialog + archive client
- `gui/Actions.java`, `gui/component/MenuBar.java` — the `New PUNCH Layer…` menu action
- `layers/selector/ImageLayerOptions.java` — minor
- `resources/settings/colors.js` — the `WFI+NFI Mosaic` → `PUNCH` rule

## Testing
Builds clean (`ant compile`, rebased on current `master`). Smoke-tested in-app on macOS/Metal:
browsed levels/products, the coverage probe set a valid range, searched and loaded CAM and PTM
mosaics, and confirmed they come up in the PUNCH color table (not gray) with the LUT still
user-changeable.

## Notes / follow-ups (separate stacked PRs)
Two independent follow-ups build on this: a per-layer **refresh** button (re-query the archive for
new frames) and a **shared movie display range** (so a multi-frame FITS movie doesn't strobe as
each frame auto-normalizes). Kept separate to keep this PR to "add the source."
