### PR TITLE
Add a per-layer refresh button for PUNCH layers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
   screen space to structures near the Sun while keeping the solar disk linear. (by @GillySpace27)
 - Remove the redundant Polar and LogPolar projections, subsumed by RectWarp
 - Add grid line color, opacity and width controls to the grid layer (by @GillySpace27)
+- Add a per-layer refresh button to check the PUNCH archive for new frames (by @GillySpace27)
 
 ### Timeline, events, and UI
 - Map HEK Flare Trigger events to Flare events (fixes #105)

--- a/src/org/helioviewer/jhv/gui/dialog/PunchDialog.java
+++ b/src/org/helioviewer/jhv/gui/dialog/PunchDialog.java
@@ -135,8 +135,11 @@ public class PunchDialog extends StandardDialog implements PunchClient.ReceiverI
                 if (choice != JOptionPane.OK_OPTION)
                     return;
             }
-            PunchClient.submitLoad(items);
-            setVisible(false);
+            if (levelCombo.getSelectedItem() instanceof String level && productCombo.getSelectedItem() instanceof String product &&
+                    cadenceCombo.getSelectedItem() instanceof Cadence cadence) {
+                PunchClient.submitLoad(items, level, product, timeSelectorPanel.getStartTime(), timeSelectorPanel.getEndTime(), cadence.milli);
+                setVisible(false);
+            }
         });
         return loadButton;
     }

--- a/src/org/helioviewer/jhv/io/PunchClient.java
+++ b/src/org/helioviewer/jhv/io/PunchClient.java
@@ -5,8 +5,13 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -15,6 +20,7 @@ import javax.annotation.Nonnull;
 
 import org.helioviewer.jhv.app.Commands;
 import org.helioviewer.jhv.app.Log;
+import org.helioviewer.jhv.layers.ImageLayer;
 import org.helioviewer.jhv.thread.Task;
 import org.helioviewer.jhv.time.TimeUtils;
 
@@ -61,8 +67,60 @@ public final class PunchClient {
         Task.submit("punch", new QueryCoverage(level, product), receiver::setPunchResponseCoverage, "Error listing the PUNCH archive");
     }
 
-    public static void submitLoad(@Nonnull List<DataItem> items) {
-        Commands.loadImage(items.stream().map(DataItem::uri).toList());
+    public static void submitLoad(@Nonnull List<DataItem> items, @Nonnull String level, @Nonnull String product, long start, long end, long cadence) {
+        List<URI> uris = items.stream().map(DataItem::uri).toList();
+        Commands.loadImage(uris).thenAccept(layer -> {
+            if (layer != null)
+                rememberQuery(layer, level, product, start, end, cadence, uris);
+        });
+    }
+
+    // ---- per-layer query state, for the "check missing frames" refresh action -----
+
+    public record RefreshResult(int existingCount, int newCount, ImageLayer newLayer) {}
+
+    public interface RefreshReceiver {
+        void onRefreshComplete(RefreshResult result);
+    }
+
+    private record QueryState(String level, String product, long start, long end, long cadence, Set<URI> loadedUris) {}
+
+    // Weak so we do not pin layers that the user has removed
+    private static final Map<ImageLayer, QueryState> layerQueries = Collections.synchronizedMap(new WeakHashMap<>());
+
+    static void rememberQuery(ImageLayer layer, String level, String product, long start, long end, long cadence, List<URI> uris) {
+        layerQueries.put(layer, new QueryState(level, product, start, end, cadence, new HashSet<>(uris)));
+    }
+
+    public static boolean hasRememberedQuery(ImageLayer layer) {
+        return layerQueries.containsKey(layer);
+    }
+
+    // Re-runs the original query, diffs against the URIs we already loaded for this layer,
+    // and loads any new ones as a fresh layer (so the user can compare or replace)
+    public static void submitRefresh(@Nonnull ImageLayer layer, @Nonnull RefreshReceiver receiver) {
+        QueryState q = layerQueries.get(layer);
+        if (q == null) {
+            receiver.onRefreshComplete(new RefreshResult(0, 0, null));
+            return;
+        }
+        Task.submit("punch-refresh", new QueryItems(q.level, q.product, q.start, q.end, q.cadence), items -> {
+            List<URI> newUris = new ArrayList<>();
+            for (DataItem it : items)
+                if (!q.loadedUris.contains(it.uri))
+                    newUris.add(it.uri);
+            if (newUris.isEmpty()) {
+                receiver.onRefreshComplete(new RefreshResult(q.loadedUris.size(), 0, null));
+                return;
+            }
+            Commands.loadImage(newUris).thenAccept(newLayer -> {
+                // Track the union on the original layer so a second refresh diffs correctly
+                q.loadedUris.addAll(newUris);
+                if (newLayer != null)
+                    rememberQuery(newLayer, q.level, q.product, q.start, q.end, q.cadence, newUris);
+                receiver.onRefreshComplete(new RefreshResult(q.loadedUris.size() - newUris.size(), newUris.size(), newLayer));
+            });
+        }, "Error refreshing PUNCH layer");
     }
 
     private static String readIndex(String url) throws Exception {

--- a/src/org/helioviewer/jhv/layers/selector/ImageLayerOptions.java
+++ b/src/org/helioviewer/jhv/layers/selector/ImageLayerOptions.java
@@ -10,11 +10,13 @@ import javax.swing.BorderFactory;
 import javax.swing.JPanel;
 import javax.swing.JProgressBar;
 
+import org.helioviewer.jhv.app.Message;
 import org.helioviewer.jhv.gui.CompletionNotifications;
 import org.helioviewer.jhv.gui.component.Buttons;
 import org.helioviewer.jhv.gui.component.CircularProgressUI;
 import org.helioviewer.jhv.gui.dialog.MetaDataDialog;
 import org.helioviewer.jhv.io.DownloadLayer;
+import org.helioviewer.jhv.io.PunchClient;
 import org.helioviewer.jhv.layers.ImageLayer;
 import org.helioviewer.jhv.layers.Layer;
 import org.helioviewer.jhv.layers.filters.ChannelMixerPanel;
@@ -136,9 +138,38 @@ final class ImageLayerOptions extends JPanel {
             metaDialog.showDialog();
         });
 
+        // Only PUNCH layers carry a remembered query; the button stays hidden otherwise
+        JideButton refreshButton = new JideButton(Buttons.refresh);
+        refreshButton.setToolTipText("Check the PUNCH archive for new frames in this layer's time range");
+        refreshButton.setVisible(PunchClient.hasRememberedQuery(layer));
+        JProgressBar refreshSpinner = new JProgressBar();
+        refreshSpinner.setUI(new CircularProgressUI());
+        refreshSpinner.setIndeterminate(true);
+        refreshSpinner.setVisible(false);
+        refreshSpinner.setPreferredSize(new Dimension(20, 20));
+        refreshButton.addActionListener(e -> {
+            refreshButton.setEnabled(false);
+            refreshButton.setText(null);
+            refreshButton.add(refreshSpinner);
+            refreshSpinner.setVisible(true);
+            PunchClient.submitRefresh(layer, result -> {
+                refreshSpinner.setVisible(false);
+                refreshButton.remove(refreshSpinner);
+                refreshButton.setText(Buttons.refresh);
+                refreshButton.setEnabled(true);
+                Message.warn("PUNCH refresh", result.newCount() == 0
+                        ? "No new frames in the archive for this layer."
+                        : String.format("Loaded %d new frame%s as a new layer.", result.newCount(), result.newCount() == 1 ? "" : "s"));
+            });
+        });
+
+        JPanel rightCluster = new JPanel(new BorderLayout());
+        rightCluster.add(refreshButton, BorderLayout.LINE_START);
+        rightCluster.add(metaButton, BorderLayout.LINE_END);
+
         JPanel buttonPanel = new JPanel(new BorderLayout());
         buttonPanel.add(downloadButton, BorderLayout.LINE_START);
-        buttonPanel.add(metaButton, BorderLayout.LINE_END);
+        buttonPanel.add(rightCluster, BorderLayout.LINE_END);
 
         c.gridx = 2;
         c.anchor = GridBagConstraints.LINE_END;


### PR DESCRIPTION
> **🔗 Stacked on #328.** This branch contains #328's source commit plus one new commit —
> **only the final commit, "Add a per-layer refresh button for PUNCH layers", is new here;
> review that one.** I'll rebase onto `master` once #328 lands, at which point the diff
> collapses to just that commit. Draft until then.

## What this adds
The PUNCH archive is appended to continuously, so a layer you loaded an hour ago may be missing
the latest frames. This adds a small **refresh** button to a PUNCH layer's options:

- It remembers each PUNCH layer's archive query (level / product / time range / cadence) in a
  weak map (so removed layers aren't pinned).
- Clicking it re-runs that query, diffs against the frames already loaded, and loads any **new**
  frames as a fresh layer (so you can compare or replace).
- The button is hidden for non-PUNCH layers (only layers with a remembered query show it).

## Why a separate PR
It's a self-contained UI feature on top of the PUNCH source; independent of the display-range
follow-up. Kept separate so the source PR stays minimal.

## Testing
Builds clean (`ant compile`, rebased on current `master`).
