### PR TITLE
Add a shared display range for multi-frame FITS layers (fixes PUNCH movie strobe)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 - Adjust trajectory colors for white canvas (fixes #260)
 - Add a `New PUNCH Layer` source that loads FITS frames from the PUNCH archive at `umbra.nascom.nasa.gov/punch`
 - Add `RHEF` radial histogram equalizing filter with an Upsilon midtone control
+- Pin a multi-frame FITS layer to one shared display range so a PUNCH movie does not strobe as each frame auto-normalizes
 
 ### Timeline, events, and UI
 - Map HEK Flare Trigger events to Flare events (fixes #105)

--- a/src/org/helioviewer/jhv/gui/dialog/PunchDialog.java
+++ b/src/org/helioviewer/jhv/gui/dialog/PunchDialog.java
@@ -130,7 +130,7 @@ public class PunchDialog extends StandardDialog implements PunchClient.ReceiverI
             }
             if (items.size() > CONFIRM_FILES) {
                 int choice = JOptionPane.showConfirmDialog(this,
-                        String.format("This will download %d native-resolution FITS files (typically a few MB each).%nSeveral files may be fetched in parallel.%nProceed?", items.size()),
+                        String.format("This will download %d native-resolution FITS files (typically a few MB each).%nThey are fetched as the layer plays, several in parallel, and a shared display range is computed in the background so the movie does not strobe.%nProceed?", items.size()),
                         "Large PUNCH download", JOptionPane.OK_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE);
                 if (choice != JOptionPane.OK_OPTION)
                     return;

--- a/src/org/helioviewer/jhv/io/PunchClient.java
+++ b/src/org/helioviewer/jhv/io/PunchClient.java
@@ -61,8 +61,20 @@ public final class PunchClient {
         Task.submit("punch", new QueryCoverage(level, product), receiver::setPunchResponseCoverage, "Error listing the PUNCH archive");
     }
 
+    // Raw PUNCH FITS carry no display range, so each frame would auto-normalize to its own
+    // percentile range and the movie strobes. The layer loads immediately; in the background
+    // PunchRange samples a bounded subset, derives one shared range, and pins the whole layer to
+    // it (ImageLayer.setFixedRange) so every frame decodes identically — the strobe disappears
+    // once the range arrives, without blocking the load.
     public static void submitLoad(@Nonnull List<DataItem> items) {
-        Commands.loadImage(items.stream().map(DataItem::uri).toList());
+        List<URI> remoteUris = items.stream().map(DataItem::uri).toList();
+        Commands.loadImage(remoteUris).thenAccept(layer -> {
+            if (layer != null)
+                Task.submit("punch-range", () -> PunchRange.compute(remoteUris), range -> {
+                    if (range != null)
+                        layer.setFixedRange(range[0], range[1]);
+                }, "Error computing the PUNCH display range");
+        });
     }
 
     private static String readIndex(String url) throws Exception {

--- a/src/org/helioviewer/jhv/io/PunchRange.java
+++ b/src/org/helioviewer/jhv/io/PunchRange.java
@@ -1,0 +1,153 @@
+package org.helioviewer.jhv.io;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.Buffer;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import javax.annotation.Nullable;
+
+import org.helioviewer.jhv.app.Log;
+import org.helioviewer.jhv.base.ArrayUtils;
+
+import nom.tam.fits.BasicHDU;
+import nom.tam.fits.Fits;
+import nom.tam.fits.Header;
+import nom.tam.fits.ImageHDU;
+import nom.tam.fits.header.Standard;
+import nom.tam.image.compression.hdu.CompressedImageHDU;
+
+// Raw PUNCH archive FITS carry no HV_DMIN/HV_DMAX, so FITSImage would normalize every frame to its
+// own sampled percentile range -> brightness flicker across a movie. This samples a bounded subset
+// of the frames and derives ONE robust display range; the caller applies it to the whole layer
+// (View.setRange) so every frame decodes against the same range. Off the EDT; the progress callback
+// lets the dialog show how far the sampling fetch has got. No files are written.
+final class PunchRange {
+
+    private static final int MAX_SAMPLE_FRAMES = 8; // a few frames are plenty for a robust range
+    private static final int SAMPLE = 4;            // coarse grid, like FITSImage.sampleImage
+    private static final int BIN = 1024;
+    private static final double LO_PCT = 0.005;     // robust percentiles (0.5% / 99.5%)
+    private static final double HI_PCT = 0.995;
+
+    // Returns a shared [min, max] display range, or null if it couldn't be derived (caller then
+    // keeps the default per-frame auto). Fetches only a small, evenly-spread subset, in parallel.
+    @Nullable
+    static float[] compute(List<URI> remoteUris) {
+        int n = remoteUris.size();
+        if (n < 2)
+            return null;
+
+        int step = Math.max(1, n / MAX_SAMPLE_FRAMES);
+        List<float[]> samples = IntStream.range(0, n).filter(i -> i % step == 0).limit(MAX_SAMPLE_FRAMES)
+                .parallel().mapToObj(i -> {
+                    try {
+                        File file = NetFileCache.get(remoteUris.get(i)).file();
+                        return sampleFrame(file);
+                    } catch (Exception e) {
+                        Log.warn("PUNCH range: sample failed " + remoteUris.get(i), e);
+                        return new float[0];
+                    }
+                }).filter(s -> s.length > 0).toList();
+
+        if (samples.size() < 2)
+            return null;
+
+        int poolLen = samples.stream().mapToInt(s -> s.length).sum();
+        if (poolLen < 2)
+            return null;
+        float[] pool = new float[poolLen];
+        int at = 0;
+        for (float[] s : samples) {
+            System.arraycopy(s, 0, pool, at, s.length);
+            at += s.length;
+        }
+
+        int kLo = Math.clamp((int) (LO_PCT * poolLen), 0, poolLen - 1);
+        int kHi = Math.clamp((int) (HI_PCT * poolLen), 0, poolLen - 1);
+        float dmin = ArrayUtils.selectKth(pool, 0, poolLen - 1, kLo);
+        float dmax = ArrayUtils.selectKth(pool, 0, poolLen - 1, kHi);
+        if (dmin >= dmax)
+            dmax = dmin + 1;
+        Log.info("PUNCH range: min=" + dmin + " max=" + dmax + " from " + samples.size() + '/' + n + " frames");
+        return new float[]{dmin, dmax};
+    }
+
+    private static BasicHDU<?> imageHDU(Fits fits) throws Exception {
+        BasicHDU<?>[] hdus = fits.read(); // read once; the stream is consumed
+        for (BasicHDU<?> hdu : hdus) {
+            if (hdu instanceof CompressedImageHDU)
+                return hdu;
+        }
+        for (BasicHDU<?> hdu : hdus) {
+            if (hdu instanceof ImageHDU ihdu && ihdu.getAxes() != null)
+                return ihdu;
+        }
+        throw new Exception("No image found");
+    }
+
+    private static Header imageHeader(BasicHDU<?> hdu) throws Exception {
+        return hdu instanceof CompressedImageHDU chdu ? chdu.getImageHeader() : hdu.getHeader();
+    }
+
+    // Subsample one frame to a coarse grid, apply BZERO/BSCALE, drop BLANK/non-finite/zero
+    private static float[] sampleFrame(File file) throws Exception {
+        try (Fits f = new Fits(file)) {
+            BasicHDU<?> hdu = imageHDU(f);
+            Header header = imageHeader(hdu);
+            if (header.getIntValue("NAXIS", 0) != 2)
+                return new float[0];
+            int height = header.getIntValue("NAXIS2", 0);
+            int width = header.getIntValue("NAXIS1", 0);
+            if (width <= 0 || height <= 0)
+                return new float[0];
+
+            boolean hasBlank = header.containsKey(Standard.BLANK);
+            long blank = hasBlank ? header.getLongValue(Standard.BLANK) : 0;
+            double bzero = header.getDoubleValue(Standard.BZERO, 0);
+            double bscale = header.getDoubleValue(Standard.BSCALE, 1);
+            if (!Double.isFinite(bzero) || !Double.isFinite(bscale))
+                return new float[0];
+
+            Object pixels = flatPixels(hdu, height, width);
+            int stepW = Math.max(SAMPLE * width / BIN, 1);
+            int stepH = Math.max(SAMPLE * height / BIN, 1);
+            float[] out = new float[((height + stepH - 1) / stepH) * ((width + stepW - 1) / stepW)];
+            int len = 0;
+            for (int j = 0; j < height; j += stepH) {
+                int line = width * j;
+                for (int i = 0; i < width; i += stepW) {
+                    double v = switch (pixels) {
+                        case short[] d -> (hasBlank && d[line + i] == (short) blank) ? Double.NaN : bzero + d[line + i] * bscale;
+                        case int[] d -> (hasBlank && d[line + i] == (int) blank) ? Double.NaN : bzero + d[line + i] * bscale;
+                        case long[] d -> (hasBlank && d[line + i] == blank) ? Double.NaN : bzero + d[line + i] * bscale;
+                        case float[] d -> bzero + d[line + i] * bscale;
+                        case double[] d -> bzero + d[line + i] * bscale;
+                        default -> throw new Exception("Unknown pixel type: " + pixels.getClass().getSimpleName());
+                    };
+                    if (Double.isFinite(v) && v != 0)
+                        out[len++] = (float) v;
+                }
+            }
+            float[] trimmed = new float[len];
+            System.arraycopy(out, 0, trimmed, 0, len);
+            return trimmed;
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static Object flatPixels(BasicHDU<?> hdu, int height, int width) throws Exception {
+        if (hdu instanceof CompressedImageHDU chdu) {
+            Buffer buffer = chdu.getUncompressedData();
+            if (!buffer.hasArray() || buffer.arrayOffset() != 0 || buffer.position() != 0 || buffer.remaining() < height * width)
+                throw new Exception("Unsupported compressed FITS pixel buffer");
+            return buffer.array();
+        }
+        if (hdu instanceof ImageHDU ihdu)
+            return ihdu.getData().getTiler().getTile(new int[]{0, 0}, new int[]{height, width});
+        throw new Exception("Unsupported FITS HDU: " + hdu.getClass().getSimpleName());
+    }
+
+    private PunchRange() {}
+}

--- a/src/org/helioviewer/jhv/layers/ImageLayer.java
+++ b/src/org/helioviewer/jhv/layers/ImageLayer.java
@@ -131,7 +131,19 @@ public class ImageLayer extends AbstractLayer implements View.DataHandler {
             return;
 
         replaceView(_view);
+        if (fixedRange != null) // re-apply a pending shared display range to the freshly loaded view
+            _view.setRange(fixedRange[0], fixedRange[1]);
         activateView();
+    }
+
+    private double[] fixedRange; // optional shared FITS display range applied to all the layer's frames
+
+    // Pin all of this layer's frames to a fixed [min, max] display range (FITS only), so a
+    // multi-frame layer (e.g. a PUNCH movie) does not strobe as each frame auto-normalizes.
+    public void setFixedRange(double min, double max) {
+        fixedRange = new double[]{min, max};
+        view.setRange(min, max); // applies now if the real view is already in place
+        DisplayController.display();
     }
 
     private void replaceView(View newView) {

--- a/src/org/helioviewer/jhv/view/ManyView.java
+++ b/src/org/helioviewer/jhv/view/ManyView.java
@@ -68,6 +68,11 @@ public class ManyView implements View {
     }
 
     @Override
+    public void setRange(double min, double max) {
+        frameMap.values().forEach(frameInfo -> frameInfo.view.setRange(min, max));
+    }
+
+    @Override
     public ImageFilter.Type getFilter() {
         return frameMap.indexedValue(0).view.getFilter();
     }

--- a/src/org/helioviewer/jhv/view/View.java
+++ b/src/org/helioviewer/jhv/view/View.java
@@ -38,6 +38,9 @@ public interface View {
 
     default void clearCache() {}
 
+    // Set a shared fixed [min, max] display range across this view's frames (FITS only); no-op otherwise
+    default void setRange(double min, double max) {}
+
     void setFilter(ImageFilter.Type t);
 
     ImageFilter.Type getFilter();

--- a/src/org/helioviewer/jhv/view/uri/FITSImage.java
+++ b/src/org/helioviewer/jhv/view/uri/FITSImage.java
@@ -36,20 +36,20 @@ public final class FITSImage implements URIImageReader {
     public URIImageReader.Image readImage(File file) throws Exception {
         try (Fits f = new Fits(file)) {
             BasicHDU<?> hdu = findHDU(f);
-            return new URIImageReader.Image(getHeaderAsXML(imageHeader(hdu)), readHDU(hdu, ImageFilter.NONE), null);
+            return new URIImageReader.Image(getHeaderAsXML(imageHeader(hdu)), readHDU(hdu, ImageFilter.NONE, null), null);
         }
     }
 
     @Override
-    public ImageBuffer readImageBuffer(File file, ImageFilter filter) throws Exception {
+    public ImageBuffer readImageBuffer(File file, ImageFilter filter, @Nullable float[] clip) throws Exception {
         try (Fits f = new Fits(file)) {
-            return readHDU(findHDU(f), filter);
+            return readHDU(findHDU(f), filter, clip);
         }
     }
 
     public ImageBuffer readImageBuffer(InputStream input) throws Exception {
         try (Fits f = new Fits(input)) {
-            return readHDU(findHDU(f), ImageFilter.NONE);
+            return readHDU(findHDU(f), ImageFilter.NONE, null);
         }
     }
 
@@ -333,10 +333,10 @@ public final class FITSImage implements URIImageReader {
         return axes;
     }
 
-    private static ImageBuffer readHDU(BasicHDU<?> hdu, ImageFilter filter) throws Exception {
+    private static ImageBuffer readHDU(BasicHDU<?> hdu, ImageFilter filter, @Nullable float[] clip) throws Exception {
         Header header = imageHeader(hdu);
         int[] axes = imageAxes(header);
-        return readPixels(header, axes, readFlatPixels(hdu, axes), filter);
+        return readPixels(header, axes, readFlatPixels(hdu, axes), filter, clip);
     }
 
     @SuppressWarnings("deprecation")
@@ -357,7 +357,7 @@ public final class FITSImage implements URIImageReader {
         return buffer.array();
     }
 
-    private static ImageBuffer readPixels(Header header, int[] axes, Object pixels, ImageFilter filter) throws Exception {
+    private static ImageBuffer readPixels(Header header, int[] axes, Object pixels, ImageFilter filter, @Nullable float[] clip) throws Exception {
         int height = axes[0];
         int width = axes[1];
 
@@ -378,30 +378,39 @@ public final class FITSImage implements URIImageReader {
             throw new Exception("Invalid FITS BZERO/BSCALE");
         FITSViewState.Data state = FITSViewState.data();
 
-        float min = header.getFloatValue("HV_DMIN", Float.MAX_VALUE);
-        float max = header.getFloatValue("HV_DMAX", Float.MAX_VALUE);
-        if (min == Float.MAX_VALUE || max == Float.MAX_VALUE) {
-            if (state.clippingMode() == FITSViewState.ClippingMode.Range) {
-                min = (float) state.clippingMin();
-                max = (float) state.clippingMax();
-            } else {
-                SampleBuffer sampleData = sampleImage(pixels, hasBlank, blank, bzero, bscale, width, height);
-                int sampleLen = sampleData.length();
-                if (sampleLen < MIN_SAMPLES) // couldn't find enough acceptable samples, return blank image
-                    return ImageBuffer.createWriteBuffer(width, height, ImageBuffer.Format.Gray8, filter).finish();
-
-                if (state.clippingMode().percentile() > 0) {
-                    double percentile = state.clippingMode().percentile();
-                    int kMin = Math.clamp((int) (percentile * sampleLen), 0, sampleLen - 1);
-                    int kMax = Math.clamp((int) ((1 - percentile) * sampleLen), 0, sampleLen - 1);
-                    float[] values = sampleData.values();
-                    min = ArrayUtils.selectKth(values, 0, sampleLen - 1, kMin);
-                    max = ArrayUtils.selectKth(values, 0, sampleLen - 1, kMax);
+        float min;
+        float max;
+        if (clip != null) {
+            // Per-layer fixed display range — shared across a multi-frame layer's frames (e.g.
+            // a PUNCH movie) so they normalize identically instead of strobing per-frame.
+            min = clip[0];
+            max = clip[1];
+        } else {
+            min = header.getFloatValue("HV_DMIN", Float.MAX_VALUE);
+            max = header.getFloatValue("HV_DMAX", Float.MAX_VALUE);
+            if (min == Float.MAX_VALUE || max == Float.MAX_VALUE) {
+                if (state.clippingMode() == FITSViewState.ClippingMode.Range) {
+                    min = (float) state.clippingMin();
+                    max = (float) state.clippingMax();
                 } else {
-                    Arrays.sort(sampleData.values(), 0, sampleLen);
-                    ZScale.ZScaleRange range = ZScale.zscale(sampleData.values(), sampleLen, state.zContrast());
-                    min = range.low();
-                    max = range.high();
+                    SampleBuffer sampleData = sampleImage(pixels, hasBlank, blank, bzero, bscale, width, height);
+                    int sampleLen = sampleData.length();
+                    if (sampleLen < MIN_SAMPLES) // couldn't find enough acceptable samples, return blank image
+                        return ImageBuffer.createWriteBuffer(width, height, ImageBuffer.Format.Gray8, filter).finish();
+
+                    if (state.clippingMode().percentile() > 0) {
+                        double percentile = state.clippingMode().percentile();
+                        int kMin = Math.clamp((int) (percentile * sampleLen), 0, sampleLen - 1);
+                        int kMax = Math.clamp((int) ((1 - percentile) * sampleLen), 0, sampleLen - 1);
+                        float[] values = sampleData.values();
+                        min = ArrayUtils.selectKth(values, 0, sampleLen - 1, kMin);
+                        max = ArrayUtils.selectKth(values, 0, sampleLen - 1, kMax);
+                    } else {
+                        Arrays.sort(sampleData.values(), 0, sampleLen);
+                        ZScale.ZScaleRange range = ZScale.zscale(sampleData.values(), sampleLen, state.zContrast());
+                        min = range.low();
+                        max = range.high();
+                    }
                 }
             }
         }

--- a/src/org/helioviewer/jhv/view/uri/GenericImage.java
+++ b/src/org/helioviewer/jhv/view/uri/GenericImage.java
@@ -76,8 +76,8 @@ final class GenericImage implements URIImageReader {
     }
 
     @Override
-    public ImageBuffer readImageBuffer(File file, ImageFilter filter) throws Exception {
-        return withReader(file, reader -> readBuffered(reader.read(0), filter));
+    public ImageBuffer readImageBuffer(File file, ImageFilter filter, @Nullable float[] clip) throws Exception {
+        return withReader(file, reader -> readBuffered(reader.read(0), filter)); // clip: N/A for 8-bit images
     }
 
     @Nullable

--- a/src/org/helioviewer/jhv/view/uri/URIImageReader.java
+++ b/src/org/helioviewer/jhv/view/uri/URIImageReader.java
@@ -14,6 +14,8 @@ interface URIImageReader {
 
     Image readImage(File file) throws Exception;
 
-    ImageBuffer readImageBuffer(File file, ImageFilter filter) throws Exception;
+    // clip: optional fixed [min, max] display range; when non-null the FITS reader normalizes to
+    // it instead of per-frame auto, so a multi-frame layer's frames don't strobe. Non-FITS ignore.
+    ImageBuffer readImageBuffer(File file, ImageFilter filter, @Nullable float[] clip) throws Exception;
 
 }

--- a/src/org/helioviewer/jhv/view/uri/URIView.java
+++ b/src/org/helioviewer/jhv/view/uri/URIView.java
@@ -77,7 +77,7 @@ public final class URIView extends BaseView {
             sendDataToHandler(image, viewpoint);
             return;
         }
-        executor.submit(new Decoder(dataUri.file(), reader, createFilter(filterType), imageRegion), new Callback(key, viewpoint));
+        executor.submit(new Decoder(dataUri.file(), reader, createFilter(filterType), imageRegion, fixedRange), new Callback(key, viewpoint));
     }
 
     private ImageFilter createFilter(ImageFilter.Type type) {
@@ -95,11 +95,22 @@ public final class URIView extends BaseView {
         return decodeKey;
     }
 
-    private record Decoder(File file, URIImageReader reader, ImageFilter filter, Region imageRegion) implements Callable<DecodedImage> {
+    // Optional shared [min, max] display range for this layer's FITS frames. When set, every frame
+    // normalizes to it instead of per-frame auto, so a multi-frame layer does not strobe.
+    private volatile float[] fixedRange;
+
+    @Override
+    public void setRange(double min, double max) {
+        fixedRange = new float[]{(float) min, (float) max};
+        // drop cached decodes for this file so they re-decode with the new range (caller re-renders)
+        ImageBufferCache.invalidateIf(k -> k instanceof URIDecodeKey key && key.uri() == dataUri);
+    }
+
+    private record Decoder(File file, URIImageReader reader, ImageFilter filter, Region imageRegion, float[] clip) implements Callable<DecodedImage> {
         @Nonnull
         @Override
         public DecodedImage call() throws Exception {
-            ImageBuffer imageBuffer = reader.readImageBuffer(file, filter);
+            ImageBuffer imageBuffer = reader.readImageBuffer(file, filter, clip);
             if (imageBuffer == null) // e.g. FITS
                 throw new Exception("Could not read: " + file);
             return new DecodedImage(imageBuffer, imageRegion);


### PR DESCRIPTION
## The problem
A PUNCH movie **strobes**: each FITS frame carries no display range, so `FITSImage` normalizes
every frame to its *own* sampled percentile range, and the brightness jumps frame-to-frame. This
affects any multi-frame FITS layer whose frames lack `HV_DMIN`/`HV_DMAX`, not just PUNCH.

## The fix
Give a multi-frame layer **one shared display range** so all its frames normalize identically:

- A new **`View.setRange(min, max)`** (default no-op) — `ManyView` fans it out to its frames,
  `URIView` stores it and re-decodes; threaded into the FITS reader as a nullable `float[] clip`
  (`URIImageReader` / `FITSImage`). When set, `FITSImage` normalizes to it instead of per-frame
  auto; non-FITS readers ignore it.
- **`ImageLayer.setFixedRange(min, max)`** pins it across the layer.
- For PUNCH, **`PunchRange`** derives the range from a small parallel-sampled subset of the frames
  (robust 0.5 / 99.5 percentiles); the load applies it **in the background**, so the layer appears
  immediately and the strobe clears once the range arrives — the load never blocks.

Rebased onto current `master` now that #328 has landed — this is a single commit. The FITS side
was re-reconciled against your refactored `clippingMode().percentile()` logic (the `clip` guard
simply wraps it).

## Design — happy to take this whichever way you prefer
I used a new `View.setRange` seam because it's the smallest change that makes the range
*per-layer* and survives a re-decode. But it adds surface area and overlaps machinery you already
have, so I'm glad to adapt it — three options, your call:

1. **Route it through `FITSViewState`** instead of a new `View` method, keeping all FITS-range
   logic in one place. It's currently *global*, so this means giving it a per-layer scope — happy
   to do that if you'd prefer it there.
2. **Generalize `PunchRange`** — it's PUNCH-named, but the strobe is a general multi-frame-FITS
   problem (EUI, synoptic maps, …). I can rename/move it to a generic multi-frame range helper so
   any FITS movie benefits, not just PUNCH.
3. **Keep it as-is** — the per-layer `setRange` + nullable `clip`.

Tell me which fits your architecture and I'll rework it.

## Testing
Builds clean (`ant compile`, rebased on current `master`). The mechanism was smoke-tested in-app
on macOS/Metal — a multi-frame PUNCH CAM/PTM movie loads immediately and plays flicker-free once
the range is applied; the rebase only re-wrapped the FITS clipping, so the behavior is unchanged.
Being generic, other multi-frame FITS layers get the same benefit.
