### PR TITLE
Fit the camera on entry for every projection

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 - Adjust trajectory colors for white canvas (fixes #260)
 - Add a `New PUNCH Layer` source that loads FITS frames from the PUNCH archive at `umbra.nascom.nasa.gov/punch`
 - Add `RHEF` radial histogram equalizing filter with an Upsilon midtone control
+- Fit the camera on every projection switch, so a projection no longer inherits the previous one's wheel zoom
 
 ### Timeline, events, and UI
 - Map HEK Flare Trigger events to Flare events (fixes #105)

--- a/src/org/helioviewer/jhv/display/Display.java
+++ b/src/org/helioviewer/jhv/display/Display.java
@@ -11,6 +11,11 @@ public final class Display {
 
     public static void setMapMode(MapMode _mode) {
         mode = _mode;
+        // Fit on entry: drop any wheel zoom inherited from the previous projection, then let
+        // resetCameras() re-fit the FOV to the new mode. Without the first step the incoming
+        // projection is scaled by a zoom factor that was meaningful only in the outgoing one,
+        // so switching (e.g. from a zoomed Orthographic) lands at an arbitrary scale.
+        resetViewportZoom();
         DisplayController.resetCameras();
     }
 


### PR DESCRIPTION
Split out of #325 per your note on #336 — this is independent of the projection work and of every other open PR.

## Problem

`Display.setMapMode` re-fits the FOV on a projection switch but keeps the wheel zoom (`Viewport.zoom`) from the projection you are leaving. That factor is only meaningful in the projection it was set in, so entering a new projection from a zoomed view lands at an arbitrary scale — leaving a zoomed-in Orthographic can shrink a map projection to a small patch, and an Orthographic round trip does not return to the original framing.

## Fix

Reset the viewport zoom before re-fitting, so every mode (Orthographic included) fits on entry.

One line of code. Existing projections only; no new behaviour beyond the fit.
