### PR TITLE
Add a double-ended radial mask in the layer options

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 - Adjust trajectory colors for white canvas (fixes #260)
 - Add a `New PUNCH Layer` source that loads FITS frames from the PUNCH archive at `umbra.nascom.nasa.gov/punch`
 - Add `RHEF` radial histogram equalizing filter with an Upsilon midtone control
+- Add a double-ended radial mask (inner disk and outer corona) to the layer options
 
 ### Timeline, events, and UI
 - Map HEK Flare Trigger events to Flare events (fixes #105)

--- a/src/org/helioviewer/jhv/layers/filters/InnerMaskPanel.java
+++ b/src/org/helioviewer/jhv/layers/filters/InnerMaskPanel.java
@@ -5,29 +5,45 @@ import java.awt.Component;
 import javax.swing.JLabel;
 
 import org.helioviewer.jhv.display.DisplayController;
-import org.helioviewer.jhv.gui.component.JHVSlider;
+import org.helioviewer.jhv.gui.component.JHVRangeSlider;
 import org.helioviewer.jhv.layers.ImageLayer;
-import org.helioviewer.jhv.opengl.GLImage;
+import org.helioviewer.jhv.metadata.MetaData;
+import org.helioviewer.jhv.wcs.ImageBounds;
 
+// Double-ended radial mask, normalized to the layer's outer radius: the band between the
+// two handles is shown. Low handle at 0 and high handle at 1 mask nothing; the handles
+// meeting masks the whole disk and corona. Normalized so resolution is the same fine step
+// regardless of the layer's field of view. The R_sun readout uses the layer's outer radius.
 public class InnerMaskPanel implements FilterDetails {
 
-    private final JHVSlider slider;
+    private static final int STEPS = 1000; // 0.001 of the radial extent per tick
+
+    private final JHVRangeSlider slider;
     private final JLabel label;
     private final JLabel title = new JLabel("Mask ", JLabel.RIGHT);
+    private final double outerR;
 
     public InnerMaskPanel(ImageLayer layer) {
-        slider = new JHVSlider(0, GLImage.MAX_INNER * 100, (int) (layer.getGLImage().getInnerMask() * 100));
-        label = new JLabel(formatFloat(slider.getValue() / 100.), JLabel.RIGHT);
+        MetaData m = layer.getMetaData();
+        outerR = m != null ? ImageBounds.inscribed(m) : 1; // nearest-edge radius; corner/getOuterRadius overshoot
+        int low = (int) Math.round(layer.getGLImage().getInnerMask() * STEPS);
+        int high = (int) Math.round(layer.getGLImage().getOuterMask() * STEPS);
+        slider = new JHVRangeSlider(0, STEPS, low, high);
+
+        label = new JLabel(format(low, high), JLabel.RIGHT);
         slider.addChangeListener(e -> {
-            double value = slider.getValue() / 100.;
-            layer.getGLImage().setInnerMask(value);
-            label.setText(formatFloat(value));
+            int lo = slider.getLowValue();
+            int hi = slider.getHighValue();
+            layer.getGLImage().setInnerMask(lo / (double) STEPS);
+            layer.getGLImage().setOuterMask(hi / (double) STEPS);
+            label.setText(format(lo, hi));
             DisplayController.display();
         });
     }
 
-    private static String formatFloat(double value) {
-        return "<html><p align='right'>" + String.format("%.2f", value) + "R☉</p>";
+    private String format(int lo, int hi) {
+        return "<html><p align='right'>" + String.format("%.2f", lo / (double) STEPS * outerR)
+                + "–" + String.format("%.2f", hi / (double) STEPS * outerR) + "R☉</p>";
     }
 
     @Override

--- a/src/org/helioviewer/jhv/opengl/GLImage.java
+++ b/src/org/helioviewer/jhv/opengl/GLImage.java
@@ -9,6 +9,7 @@ import org.helioviewer.jhv.image.ImageBuffer;
 import org.helioviewer.jhv.image.lut.LUT;
 import org.helioviewer.jhv.metadata.DetectorMask;
 import org.helioviewer.jhv.metadata.MetaData;
+import org.helioviewer.jhv.wcs.ImageBounds;
 import org.helioviewer.jhv.view.View;
 
 import org.json.JSONObject;
@@ -38,7 +39,10 @@ public class GLImage {
     private int deltaCRVAL1 = 0;
     private int deltaCRVAL2 = 0;
 
+    // Radial mask as fractions of the layer's inscribed radius: the band [innerMask, outerMask]
+    // is shown. innerMask = 0 and outerMask = 1 mask nothing; them meeting masks everything.
     private double innerMask = 0;
+    private double outerMask = 1;
     private double slitLeft = 0;
     private double slitRight = 1;
     // private double sector0 = -Math.PI;
@@ -90,6 +94,10 @@ public class GLImage {
 
     public void applyFilters(boolean rhefActive) {
         MetaData metaData = uploadedImageData.metaData();
+        // Radial mask scale: the layer's inscribed (nearest-edge) radius. getOuterRadius() can
+        // be Float.MAX_VALUE (unbounded FOV, e.g. AIA); the corner distance overshoots the
+        // circular FOV, so inscribed is the meaningful full-extent reference.
+        double maskRef = ImageBounds.inscribed(metaData);
         // shader.bindSector(gl, -Math.max(Math.abs(metaData.getSector0()), Math.abs(sector0)), Math.max(metaData.getSector1(), sector1));
         color[0] = (float) (opacity * red); // https://amindforeverprogramming.blogspot.com/2013/07/why-alpha-premultiplied-colour-blending.html
         color[1] = (float) (opacity * green);
@@ -104,7 +112,8 @@ public class GLImage {
                 // clamps it to white). The user's Levels (brightOffset/brightScale) still
                 // apply as a black/white-point control on the equalized output.
                 (float) brightOffset, (float) (brightScale * (rhefActive ? 1 : metaData.getResponseFactor())),
-                Math.max(metaData.getInnerRadius(), (float) innerMask), Display.getShowCorona() ? metaData.getOuterRadius() : 1,
+                Math.max(metaData.getInnerRadius(), (float) (innerMask * maskRef)),
+                Display.getShowCorona() ? (outerMask < 1 ? (float) (outerMask * maskRef) : metaData.getOuterRadius()) : 1,
                 (float) slitLeft, (float) slitRight,
                 (float) (rhefActive ? upsilonLow : 1), (float) (rhefActive ? upsilonHigh : 1));
 
@@ -181,7 +190,15 @@ public class GLImage {
     }
 
     public void setInnerMask(double mask) {
-        innerMask = Math.clamp(mask, 0, MAX_INNER);
+        innerMask = Math.clamp(mask, 0, 1);
+    }
+
+    public void setOuterMask(double mask) {
+        outerMask = Math.clamp(mask, 0, 1);
+    }
+
+    public double getOuterMask() {
+        return outerMask;
     }
 
     public void setSlit(double left, double right) {
@@ -335,6 +352,7 @@ public class GLImage {
         setSlit(jo.optDouble("slitLeft", slitLeft), jo.optDouble("slitRight", slitRight));
         // setSector(jo.optDouble("sector0", sector0), jo.optDouble("sector1", sector1));
         setInnerMask(jo.optDouble("innerMask", innerMask));
+        setOuterMask(jo.optDouble("outerMask", outerMask));
         setBrightness(jo.optDouble("brightOffset", brightOffset), jo.optDouble("brightScale", brightScale));
         setEnhanced(jo.optDouble("enhanced", enhanced));
         setUpsilon(jo.optDouble("upsilonLow", upsilonLow), jo.optDouble("upsilonHigh", upsilonHigh));
@@ -361,6 +379,7 @@ public class GLImage {
         // jo.put("sector0", getSector0());
         // jo.put("sector1", getSector1());
         jo.put("innerMask", innerMask);
+        jo.put("outerMask", outerMask);
         jo.put("brightOffset", brightOffset);
         jo.put("brightScale", brightScale);
         jo.put("enhanced", enhanced);

--- a/src/org/helioviewer/jhv/wcs/ImageBounds.java
+++ b/src/org/helioviewer/jhv/wcs/ImageBounds.java
@@ -18,6 +18,19 @@ public final class ImageBounds {
                 Math.max(Math.hypot(x0, y1), Math.hypot(x1, y1)));
     }
 
+    // Radius of the largest circle centered on the Sun that fits inside the FOV (distance to
+    // the nearest edge). Unlike radial() (the corner distance), beyond this radius the data
+    // covers only the corners, so this is the meaningful outer radius for masks and disk range.
+    public static double inscribed(MetaData metaData) {
+        Region region = metaData.getPhysicalRegion();
+        Vec2 crval = metaData.getWcsHeader().crval;
+        double right = region.urx - crval.x;
+        double left = crval.x - region.llx;
+        double top = region.ury - crval.y;
+        double bottom = crval.y - region.lly;
+        return Math.max(0, Math.min(Math.min(right, left), Math.min(top, bottom)));
+    }
+
     public static Region hpc(MetaData metaData) {
         Region region = metaData.getPhysicalRegion();
         WcsHeader wcsHeader = metaData.getWcsHeader();


### PR DESCRIPTION
Split out of #325 per your note on #336 — a layer feature, independent of the projection work. It touches no shader: only the values passed to the existing inner/outer radius uniforms.

## What this adds

The layer options had a one-ended inner mask. Coronagraph work often needs to cut the other end too — hide a noisy outer edge, or isolate a radial band — so this makes the mask a band `[innerMask, outerMask]`.

Both handles are fractions of the layer's **inscribed** radius (the largest Sun-centered circle that fits inside the FOV), so they mean the same thing across instruments with very different fields of view. `getOuterRadius()` can be unbounded (`Float.MAX_VALUE`, e.g. AIA) and `radial()` is the corner distance, beyond which data covers only the corners — neither is a usable reference, hence `ImageBounds.inscribed()`.

Masking is unchanged at `inner = 0, outer = 1`.

## The patches

1. `Add ImageBounds.inscribed()` — the geometry helper, on its own.
2. `Add a double-ended radial mask in the layer options` — the mask + its panel.
