### PR TITLE
Add grid label size and angle controls

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 - Adjust trajectory colors for white canvas (fixes #260)
 - Add a `New PUNCH Layer` source that loads FITS frames from the PUNCH archive at `umbra.nascom.nasa.gov/punch`
 - Add `RHEF` radial histogram equalizing filter with an Upsilon midtone control
+- Add a `RadialWarp` Sun-centered radial disk projection with a tunable radial exponent (p = -1 inverse, 0 logarithmic, 1 linear; only the corona beyond 1 R☉ is warped), a radial ring/spoke grid, and an automatic flat-in-disk layout for disk imagers
 
 ### Timeline, events, and UI
 - Map HEK Flare Trigger events to Flare events (fixes #105)

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,9 @@
 - Add a `New PUNCH Layer` source that loads FITS frames from the PUNCH archive at `umbra.nascom.nasa.gov/punch`
 - Add `RHEF` radial histogram equalizing filter with an Upsilon midtone control
 - Add a `RadialWarp` Sun-centered radial disk projection with a tunable radial exponent (p = -1 inverse, 0 logarithmic, 1 linear; only the corona beyond 1 R☉ is warped), a radial ring/spoke grid, and an automatic flat-in-disk layout for disk imagers
+- Add a `PowerDisk` Sun-centered radial disk projection with a tunable radial exponent (p = -1 inverse, 0 logarithmic, 1 linear; only the corona beyond 1 R☉ is warped) and an automatic flat-in-disk layout for disk imagers
+- Add a double-ended radial mask (inner disk and outer corona) to the layer options
+- Add grid line color, opacity and width controls to the grid layer (applied across the orthographic, polar and disk grids)
 
 ### Timeline, events, and UI
 - Map HEK Flare Trigger events to Flare events (fixes #105)

--- a/resources/glsl/solarCommon.frag
+++ b/resources/glsl/solarCommon.frag
@@ -55,6 +55,7 @@ struct Screen {
     float xStop;
     float yStart;
     float yStop;
+    float yParam;         // free radial-scale parameter (RadialWarp exponent inverse)
 };
 
 layout(std140) uniform ScreenBlock {
@@ -188,6 +189,14 @@ vec2 getScrPos(void) {
     vec2 scrpos = vec2(screen.iaspect * up1.x, up1.y) + .5;
     clamp_coord(scrpos);
     return scrpos;
+}
+
+// Isotropic world-plane offset from the disk center, for the disk projections:
+// getScrPos without the map-square clamp and aspect scaling.
+vec2 getDiskPos(void) {
+    vec2 normalizedScreenpos = 2. * (gl_FragCoord.xy - screen.viewport.xy) / screen.viewport.zw - 1.;
+    vec4 up1 = screen.inverseMVP * vec4(normalizedScreenpos.x, normalizedScreenpos.y, -1., 1.);
+    return up1.xy;
 }
 
 vec3 rotate_vector_inverse(const vec4 quat, const vec3 vec) {

--- a/resources/glsl/solarDiskPower.frag
+++ b/resources/glsl/solarDiskPower.frag
@@ -1,0 +1,54 @@
+
+vec2 sampleDiskTexcoord(const vec2 crval, const vec4 crota, const vec4 rect, const vec2 w, const float t, const float radialCoordinate) {
+    if (radialCoordinate > display.radii.y || radialCoordinate < display.radii.x)
+        discard;
+
+    // The disk shows the image plane with the radius remapped; same polar map
+    // convention as solarPolar.frag, 0 at north and increasing anti-clockwise.
+    // This basis must stay consistent with the Java-side non-ortho projection after
+    // the subsequent rotate_plane_inverse(..., vec2(pos.x, -pos.y) - crval) step.
+    vec2 polarXY = (2. * radialCoordinate / t) * vec2(w.x, -w.y);
+
+    if (display.cutOff.z >= 0.) {
+        // Convert the polar north-up basis to the display-plane x/y basis used by cutOff.
+        vec2 displayXY = polarXY.yx;
+        vec2 cutOffAlt = vec2(-display.cutOff.y, display.cutOff.x);
+        float geometryFlatDist = abs(dot(displayXY, display.cutOff.xy));
+        float geometryFlatDistAlt = abs(dot(displayXY, cutOffAlt));
+        if (geometryFlatDist > display.cutOff.z || geometryFlatDistAlt > display.cutOff.z)
+            discard;
+    }
+
+    vec2 centered = rotate_plane_inverse(crota, vec2(polarXY.x, -polarXY.y) - crval);
+    vec2 texCoord = rect.zw * vec2(centered.x - rect.x, -centered.y - rect.y);
+    clamp_texture(texCoord);
+    return texCoord;
+}
+
+void main(void) {
+    vec4 color;
+    vec2 w = getDiskPos();
+    float t = 2. * length(w);
+    if (t > 1. || t == 0.)
+        discard;
+    float angle = atan(-w.x, w.y);
+    if (angle < 0.)
+        angle += TWOPI;
+    clamp_coord(vec2(angle / TWOPI, t));
+    // Match PowerMapScale: linear inside the limb (scaled <= 1), power-law outside.
+    // screen.yParam = p; p == 0 is the exact logarithmic endpoint.
+    float scaled = screen.yStart + t * (screen.yStop - screen.yStart);
+    float p = screen.yParam;
+    float radialCoordinate = scaled <= 1. ? scaled
+            : (p == 0. ? exp(scaled - 1.) : pow(1. + p * (scaled - 1.), 1. / p));
+    float enhancementFactor = max(1., radialCoordinate);
+    bool diffMode = display.isDiff != NODIFFERENCE;
+    vec2 texCoord = sampleDiskTexcoord(wcs[0].crval, wcs[0].crota, wcs[0].rect, w, t, radialCoordinate);
+    if (!diffMode) {
+        color = getColor(texCoord, texCoord, enhancementFactor);
+    } else {
+        vec2 diffTexCoord = sampleDiskTexcoord(wcs[1].crval, wcs[1].crota, wcs[1].rect, w, t, radialCoordinate);
+        color = getColor(texCoord, diffTexCoord, enhancementFactor);
+    }
+    outColor = color;
+}

--- a/src/org/helioviewer/jhv/display/Display.java
+++ b/src/org/helioviewer/jhv/display/Display.java
@@ -20,6 +20,16 @@ public final class Display {
         gridType = _gridType;
     }
 
+    private static double diskPower = 0.0; // default to logarithmic (mid-scale, most dramatic)
+
+    public static double getDiskPower() {
+        return diskPower;
+    }
+
+    public static void setDiskPower(double p) {
+        diskPower = Math.clamp(p, -1, 1); // -1 = inverse, 0 = logarithmic, 1 = linear
+    }
+
     static int glWidth = 1;
     static int glHeight = 1;
     public static final double[] pixelScale = {1, 1};

--- a/src/org/helioviewer/jhv/display/MapMode.java
+++ b/src/org/helioviewer/jhv/display/MapMode.java
@@ -10,14 +10,19 @@ public enum MapMode {
     HPC(GLSLSolarShader.hpc, Kind.HPC),
     Latitudinal(GLSLSolarShader.lati, Kind.LATITUDINAL),
     LogPolar(GLSLSolarShader.logpolar, Kind.POLAR),
-    Polar(GLSLSolarShader.polar, Kind.POLAR);
+    Polar(GLSLSolarShader.polar, Kind.POLAR),
+    RadialWarp(GLSLSolarShader.diskPower, Kind.DISK);
 
     enum Kind {
-        ORTHOGRAPHIC, HPC, LATITUDINAL, POLAR
+        ORTHOGRAPHIC, HPC, LATITUDINAL, POLAR, DISK
     }
 
     public final GLSLSolarShader shader;
     final Kind kind;
+
+    public boolean isDisk() {
+        return kind == Kind.DISK;
+    }
 
     MapMode(GLSLSolarShader _shader, Kind _kind) {
         shader = _shader;

--- a/src/org/helioviewer/jhv/display/MapScale.java
+++ b/src/org/helioviewer/jhv/display/MapScale.java
@@ -16,6 +16,11 @@ public interface MapScale {
 
     double getYstop();
 
+    // Free radial-scale parameter passed to the shaders (power-law exponent inverse)
+    default double getYParam() {
+        return 1;
+    }
+
     MapScale ortho = new LinearMapScale(0, 0, 0, 0);
     MapScale lati = new LatitudinalMapScale(-180, 180, -90, 90);
 
@@ -29,6 +34,13 @@ public interface MapScale {
 
     static MapScale logpolar(double radialSize) {
         return new LogMapScale(0, 360, 0.05, Math.max(0.05, radialSize));
+    }
+
+    static MapScale diskPower(double radialSize) {
+        // Inner bound pinned to 0 so the sub-limb mapping is linear through the origin
+        // (a disk imager and the grid stay locked at every radius); the outer extent fits
+        // the loaded layers. Radial compression is the p slider; masking is the per-layer mask.
+        return new PowerMapScale(0, 360, 0, Math.max(radialSize, 1));
     }
 
     abstract class MapScaleBase implements MapScale {
@@ -126,6 +138,56 @@ public interface MapScale {
         @Override
         public double invScaleY(double val) {
             return Math.exp(val);
+        }
+
+    }
+
+    final class PowerMapScale extends MapScaleBase {
+
+        // Read live (not an instance field: the superclass constructor calls scaleY());
+        // the slider takes effect through the per-render scale rebuild
+        private static double power() {
+            return Display.getDiskPower();
+        }
+
+        PowerMapScale(double _xStart, double _xStop, double _yStart, double _yStop) {
+            super(_xStart, _xStop, _yStart, _yStop);
+        }
+
+        @Override
+        public double getYParam() {
+            return power(); // the shader receives p directly (p == 0 is the log endpoint)
+        }
+
+        @Override
+        public double scaleX(double val) {
+            return val;
+        }
+
+        @Override
+        public double invScaleX(double val) {
+            return val;
+        }
+
+        // Piecewise: linear inside the limb so r <= 1 R_sun stays an undistorted disk that
+        // matches the flat-in-disk overlay at any exponent; power-law compression outside.
+        // C1-continuous at r = 1. This is the Box-Cox family (r^p - 1)/p: p = 1 linear,
+        // p = 0 logarithmic (the limit -> ln r), p = -1 inverse (2 - 1/r, bounding r = inf
+        // to a finite edge). The slider exposes p in [-1, 1].
+        @Override
+        public double scaleY(double val) {
+            double p = power();
+            if (val <= 1)
+                return val;
+            return p == 0 ? 1 + Math.log(val) : 1 + (Math.pow(val, p) - 1) / p;
+        }
+
+        @Override
+        public double invScaleY(double val) {
+            double p = power();
+            if (val <= 1)
+                return val;
+            return p == 0 ? Math.exp(val - 1) : Math.pow(1 + p * (val - 1), 1 / p);
         }
 
     }

--- a/src/org/helioviewer/jhv/display/MapView.java
+++ b/src/org/helioviewer/jhv/display/MapView.java
@@ -10,6 +10,11 @@ import org.helioviewer.jhv.opengl.BufVertex;
 
 public abstract class MapView {
 
+    // The disk projection works in a normalized radial space (rim at w-radius 0.5), so it fits
+    // the viewport at camera width ~1 regardless of the orthographic R_sun FOV. A small margin
+    // keeps the outer rim off the very edge.
+    static final double DISK_FIT_WIDTH = 1.1;
+
     protected final Camera camera;
     protected final Position viewpoint;
     protected final MapMode mode;
@@ -90,6 +95,10 @@ public abstract class MapView {
         return mode == MapMode.LogPolar;
     }
 
+    public boolean isDisk() {
+        return mode.kind == MapMode.Kind.DISK;
+    }
+
     public Vec3 mouseToSky(Viewport vp, int x, int y) {
         return ViewportMath.unprojectToCurrentViewSphereOrPlane(camera, vp, cameraWidth(vp), x, y);
     }
@@ -163,8 +172,17 @@ public abstract class MapView {
                 case HPC -> ProjectedMap.Kind.HPC;
                 case LATITUDINAL -> ProjectedMap.Kind.LATITUDINAL;
                 case POLAR -> ProjectedMap.Kind.POLAR;
+                case DISK -> ProjectedMap.Kind.DISK;
                 case ORTHOGRAPHIC -> throw new IllegalArgumentException("Orthographic mode has no projected kind");
             };
+        }
+
+        // The disk must not inherit Ortho's R_sun camera width (it would collapse to a dot when
+        // switched in from a zoomed-out view); fit it to the viewport and let the wheel zoom
+        // (vp.zoom) scale it from there. Render and mouse mapping both read this, so they stay in sync.
+        @Override
+        public double cameraWidth(Viewport vp) {
+            return kind == ProjectedMap.Kind.DISK ? DISK_FIT_WIDTH * vp.zoom : super.cameraWidth(vp);
         }
 
         @Override
@@ -174,7 +192,7 @@ public abstract class MapView {
 
         @Override
         public Vec2 mouseToGrid(Viewport vp, int x, int y) {
-            return ProjectedMap.mouseToGrid(camera, cameraWidth(vp), vp, scale(vp), gridType, x, y);
+            return ProjectedMap.mouseToGrid(kind, camera, cameraWidth(vp), vp, scale(vp), gridType, x, y);
         }
 
         @Override
@@ -184,7 +202,7 @@ public abstract class MapView {
 
         @Override
         public Vec2 mouseToScreen(Viewport vp, int x, int y) {
-            return ProjectedMap.mouseToScreen(camera, cameraWidth(vp), vp, scale(vp), x, y);
+            return ProjectedMap.mouseToScreen(kind, camera, cameraWidth(vp), vp, scale(vp), x, y);
         }
 
         @Override

--- a/src/org/helioviewer/jhv/display/ProjectedMap.java
+++ b/src/org/helioviewer/jhv/display/ProjectedMap.java
@@ -14,13 +14,14 @@ import org.helioviewer.jhv.wcs.WcsProjection;
 
 final class ProjectedMap {
 
-    enum Kind {HPC, LATITUDINAL, POLAR}
+    enum Kind {HPC, LATITUDINAL, POLAR, DISK}
 
     static Vec2 project(Kind kind, Position viewpoint, MapScale scale, Quat rotation, Vec3 v) {
         return switch (kind) {
             case HPC -> projectHpc(viewpoint, v, scale);
             case LATITUDINAL -> projectLatitudinal(rotation, scale, v);
             case POLAR -> projectPolar(rotation, scale, v);
+            case DISK -> projectDisk(rotation, scale, v);
         };
     }
 
@@ -28,13 +29,13 @@ final class ProjectedMap {
         return switch (kind) {
             case HPC -> unprojectHpc(viewpoint, pt.x, pt.y);
             case LATITUDINAL -> unprojectLatitudinal(rotation, pt.x, pt.y);
-            case POLAR -> unprojectPolar(rotation, pt.x, pt.y);
+            case POLAR, DISK -> unprojectPolar(rotation, pt.x, pt.y);
         };
     }
 
     static Vec3 mouseToSurface(Kind kind, Camera camera, Position viewpoint, double width, Viewport vp, MapScale scale, GridType gridType, int x, int y) {
         Quat rotation = gridType.mapRotation(viewpoint);
-        return unproject(kind, viewpoint, rotation, mouseToGrid(camera, width, vp, scale, gridType, x, y));
+        return unproject(kind, viewpoint, rotation, mouseToGrid(kind, camera, width, vp, scale, gridType, x, y));
     }
 
     // See docs/non-ortho-projection-note.md for the shared Java/GLSL convention.
@@ -54,6 +55,18 @@ final class ProjectedMap {
         return rotation.rotateInverseVector(unprojectPolarPoint(angleDeg, radius));
     }
 
+    private static Vec2 projectDisk(Quat rotation, MapScale scale, Vec3 v0) {
+        // The disk shows the image plane with the radius remapped: a point at radius r
+        // lands at fraction t of the disk radius 0.5, along its image-plane direction.
+        Vec3 v = rotation.rotateVector(v0);
+        double r = Math.hypot(v.x, v.y);
+        if (r == 0)
+            return new Vec2(0, 0);
+        double t = Math.max(0, scale.getYValueInv(r) + .5);
+        double f = .5 * t / r;
+        return new Vec2(f * v.x, f * v.y);
+    }
+
     private static Vec2 projectHpc(Position viewpoint, Vec3 v, MapScale scale) {
         // External solar points arrive in world space; HPC projection is defined in viewpoint space.
         return projectHpcViewpointSpace(toHpcViewpointSpace(viewpoint, v), viewpoint.distance, scale);
@@ -65,7 +78,8 @@ final class ProjectedMap {
 
     static Vec2 projectToScreen(Kind kind, Position viewpoint, MapScale scale, Quat rotation, Viewport vp, Vec3 v) {
         Vec2 pt = project(kind, viewpoint, scale, rotation, v);
-        return new Vec2(pt.x * vp.aspect, pt.y);
+        // Disk coordinates are isotropic, not stretched to the map rectangle
+        return kind == Kind.DISK ? pt : new Vec2(pt.x * vp.aspect, pt.y);
     }
 
     static void emitMapLine(Kind kind, Position viewpoint, MapScale scale, Quat rotation, Viewport vp, List<Vec3> vertices, byte[] color, BufVertex vexBuf) {
@@ -73,6 +87,10 @@ final class ProjectedMap {
             return;
         if (kind == Kind.HPC) {
             emitHpcLine(viewpoint, scale, vp, vertices, color, vexBuf);
+            return;
+        }
+        if (kind == Kind.DISK) {
+            emitDiskLine(viewpoint, scale, rotation, vertices, color, vexBuf);
             return;
         }
 
@@ -83,6 +101,18 @@ final class ProjectedMap {
             Vec2 previous = current;
             current = project(kind, viewpoint, scale, rotation, vertices.get(i));
             emitWrappedVertex(vp, previous, current, color, vexBuf);
+        }
+        vexBuf.repeatVertex(Colors.Null);
+    }
+
+    private static void emitDiskLine(Position viewpoint, MapScale scale, Quat rotation, List<Vec3> vertices, byte[] color, BufVertex vexBuf) {
+        // The disk has no angular seam, so no horizontal wrap
+        Vec2 current = project(Kind.DISK, viewpoint, scale, rotation, vertices.getFirst());
+        vexBuf.putVertex((float) current.x, (float) current.y, 0, 1, Colors.Null);
+        vexBuf.repeatVertex(color);
+        for (int i = 1; i < vertices.size(); i++) {
+            current = project(Kind.DISK, viewpoint, scale, rotation, vertices.get(i));
+            vexBuf.putVertex((float) current.x, (float) current.y, 0, 1, color);
         }
         vexBuf.repeatVertex(Colors.Null);
     }
@@ -119,6 +149,13 @@ final class ProjectedMap {
         }
 
         float pointSize = (float) size;
+        if (kind == Kind.DISK) {
+            for (Vec3 vertex : vertices) {
+                Vec2 pt = project(kind, viewpoint, scale, rotation, vertex);
+                vexBuf.putVertex((float) pt.x, (float) pt.y, 0, pointSize, color);
+            }
+            return;
+        }
         for (Vec3 vertex : vertices) {
             Vec2 pt = project(kind, viewpoint, scale, rotation, vertex);
             vexBuf.putVertex((float) (pt.x * vp.aspect), (float) pt.y, 0, pointSize, color);
@@ -135,16 +172,30 @@ final class ProjectedMap {
         }
     }
 
-    static Vec2 mouseToScreen(Camera camera, double width, Viewport vp, MapScale scale, int x, int y) {
+    static Vec2 mouseToScreen(Kind kind, Camera camera, double width, Viewport vp, MapScale scale, int x, int y) {
+        if (kind == Kind.DISK) {
+            return new Vec2(
+                    ViewportMath.computeUpX(vp, width, camera.getTranslationX(), x),
+                    ViewportMath.computeUpY(vp, width, camera.getTranslationY(), y));
+        }
         Vec2 mouseGrid = mouseToRawGrid(camera, width, vp, scale, x, y);
         return new Vec2(
                 scale.getXValueInv(mouseGrid.x) * vp.aspect,
                 scale.getYValueInv(mouseGrid.y));
     }
 
-    static Vec2 mouseToGrid(Camera camera, double width, Viewport vp, MapScale scale, GridType gridType, int x, int y) {
+    static Vec2 mouseToGrid(Kind kind, Camera camera, double width, Viewport vp, MapScale scale, GridType gridType, int x, int y) {
+        if (kind == Kind.DISK)
+            return mouseToDiskGrid(camera, width, vp, scale, x, y);
         Vec2 mouseGrid = mouseToRawGrid(camera, width, vp, scale, x, y);
         return new Vec2(scale.getDisplayXValue(mouseGrid.x, gridType), mouseGrid.y);
+    }
+
+    private static Vec2 mouseToDiskGrid(Camera camera, double width, Viewport vp, MapScale scale, int x, int y) {
+        double upX = ViewportMath.computeUpX(vp, width, camera.getTranslationX(), x);
+        double upY = ViewportMath.computeUpY(vp, width, camera.getTranslationY(), y);
+        double t = 2 * Math.hypot(upX, upY);
+        return new Vec2(Math.toDegrees(PolarBasis.angle(upX, upY)), scale.getInterpolatedYValue(t));
     }
 
     private static Vec2 mouseToRawGrid(Camera camera, double width, Viewport vp, MapScale scale, int x, int y) {

--- a/src/org/helioviewer/jhv/display/ViewportMath.java
+++ b/src/org/helioviewer/jhv/display/ViewportMath.java
@@ -19,7 +19,10 @@ public final class ViewportMath {
     }
 
     private static double zoomedCameraWidth(Camera camera, Viewport vp) {
-        return camera.baseCameraWidth() * vp.zoom;
+        // Mirror MapView.cameraWidth: the disk projection renders at a normalized fit width, not the
+        // orthographic R_sun FOV, so pan/zoom/LOD sensitivity must use the same width or it desyncs.
+        double base = Display.mode.isDisk() ? MapView.DISK_FIT_WIDTH : camera.baseCameraWidth();
+        return base * vp.zoom;
     }
 
     private static double computeUpX(Camera camera, Viewport vp, double screenX) {

--- a/src/org/helioviewer/jhv/gui/component/ToolBar.java
+++ b/src/org/helioviewer/jhv/gui/component/ToolBar.java
@@ -17,6 +17,7 @@ import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.ButtonGroup;
 import javax.swing.Icon;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JRadioButtonMenuItem;
@@ -29,8 +30,11 @@ import org.helioviewer.jhv.app.Platform;
 import org.helioviewer.jhv.app.Settings;
 import org.helioviewer.jhv.app.state.ViewState;
 import org.helioviewer.jhv.base.Colors;
+import org.helioviewer.jhv.display.Display;
+import org.helioviewer.jhv.display.DisplayController;
 import org.helioviewer.jhv.display.MapMode;
 import org.helioviewer.jhv.display.interaction.Interaction;
+import org.helioviewer.jhv.layers.ImageLayers;
 import org.helioviewer.jhv.gui.Actions;
 import org.helioviewer.jhv.input.InputController;
 import org.helioviewer.jhv.io.samp.SampClient;
@@ -133,6 +137,7 @@ public final class ToolBar extends JToolBar implements ViewState.ModeListener {
     private JideToggleButton multiviewButton;
     private final EnumMap<AnnotationMode, JRadioButtonMenuItem> annotationItems = new EnumMap<>(AnnotationMode.class);
     private final EnumMap<MapMode, JRadioButtonMenuItem> projectionItems = new EnumMap<>(MapMode.class);
+    private JHVSlider radialWarpSlider; // RadialWarp radial exponent; only meaningful for that mode
     private JideToggleButton refreshButton;
     private JideToggleButton trackingButton;
 
@@ -240,6 +245,9 @@ public final class ToolBar extends JToolBar implements ViewState.ModeListener {
             projectionButton.add(item);
             projectionItems.put(el, item);
         }
+        projectionButton.addSeparator();
+        projectionButton.add(createRadialWarpPanel());
+        radialWarpSlider.setEnabled(ViewState.getProjection() == MapMode.RadialWarp);
         addButton(projectionButton);
 
         JideSplitButton annotationButton = toolSplitButton(ANNOTATION);
@@ -317,6 +325,25 @@ public final class ToolBar extends JToolBar implements ViewState.ModeListener {
             panel.add(button);
         }
         annotationButton.add(panel);
+    }
+
+    // RadialWarp radial exponent p (display radius ~ r^p): slider 0.01..2, default 1.0 (linear).
+    // power() is read live every render, so the value takes effect through the scale rebuild.
+    private JPanel createRadialWarpPanel() {
+        radialWarpSlider = new JHVSlider(-1000, 1000, (int) Math.round(Display.getDiskPower() * 1000));
+        radialWarpSlider.setToolTipText("RadialWarp radial exponent p, applied to the corona (r > 1 R☉): p = -1 inverse, p = 0 logarithmic, p = 1 linear");
+        radialWarpSlider.setPreferredSize(new Dimension(110, radialWarpSlider.getPreferredSize().height));
+        JLabel value = new JLabel(String.format("p %.3f", Display.getDiskPower()), JLabel.RIGHT);
+        radialWarpSlider.addChangeListener(e -> {
+            Display.setDiskPower(radialWarpSlider.getValue() / 1000.);
+            value.setText(String.format("p %.3f", Display.getDiskPower()));
+            DisplayController.display();
+        });
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.setBorder(BorderFactory.createEmptyBorder(3, 8, 3, 8));
+        panel.add(value, BorderLayout.LINE_START);
+        panel.add(radialWarpSlider, BorderLayout.CENTER);
+        return panel;
     }
 
     private static JPanel createAnnotationThicknessPanel() {
@@ -417,6 +444,8 @@ public final class ToolBar extends JToolBar implements ViewState.ModeListener {
         JRadioButtonMenuItem activeProjection = projectionItems.get(ViewState.getProjection());
         if (activeProjection != null)
             activeProjection.setSelected(true);
+        if (radialWarpSlider != null)
+            radialWarpSlider.setEnabled(ViewState.getProjection() == MapMode.RadialWarp);
         JRadioButtonMenuItem activeAnnotationMode = annotationItems.get(ViewState.getAnnotationMode());
         if (activeAnnotationMode != null)
             activeAnnotationMode.setSelected(true);

--- a/src/org/helioviewer/jhv/gui/status/PositionStatusPanel.java
+++ b/src/org/helioviewer/jhv/gui/status/PositionStatusPanel.java
@@ -44,7 +44,7 @@ public final class PositionStatusPanel extends StatusPanel.StatusPlugin implemen
             setText(formatHpc(coord));
         } else if (mv.isLatitudinal()) {
             setText(formatLati(coord));
-        } else if (mv.isPolar() || mv.isLogPolar()) {
+        } else if (mv.isPolar() || mv.isLogPolar() || mv.isDisk()) {
             setText(formatPolar(coord));
         } else {
             Vec3 v = mv.mouseToSky(vp, x, y);

--- a/src/org/helioviewer/jhv/layers/GridLayer.java
+++ b/src/org/helioviewer/jhv/layers/GridLayer.java
@@ -11,6 +11,7 @@ import org.helioviewer.jhv.display.GridType;
 import org.helioviewer.jhv.display.MapView;
 import org.helioviewer.jhv.display.Viewport;
 import org.helioviewer.jhv.display.ViewportMath;
+import org.helioviewer.jhv.layers.grid.DiskGrid;
 import org.helioviewer.jhv.layers.grid.FlatGrid;
 import org.helioviewer.jhv.layers.grid.GridLabel;
 import org.helioviewer.jhv.layers.grid.GridMath;
@@ -60,6 +61,7 @@ public final class GridLayer extends AbstractLayer {
     private final GLSLLine radialCircleLineFar = new GLSLLine(false);
     private final GLSLLine radialThickLineFar = new GLSLLine(false);
     private final FlatGrid flatGrid = new FlatGrid();
+    private final DiskGrid diskGrid = new DiskGrid();
     private final GLSLLine gridLine = new GLSLLine(false);
 
     private List<GridLabel> latLabels;
@@ -160,7 +162,10 @@ public final class GridLayer extends AbstractLayer {
     public void renderScale(MapView mv, Viewport vp) {
         if (!isVisible[vp.idx])
             return;
-        flatGrid.render(mv, vp, showLabels);
+        if (mv.isDisk())
+            diskGrid.render(mv, vp, showLabels, lonStep);
+        else
+            flatGrid.render(mv, vp, showLabels);
     }
 
     private void drawEarthCircles(Viewport vp, double factor, Position p) {
@@ -230,6 +235,7 @@ public final class GridLayer extends AbstractLayer {
         GridMath.initRadialCircles(radialCircleLineFar, radialThickLineFar, RADIAL_UNIT_FAR, RADIAL_STEP_FAR);
 
         flatGrid.init();
+        diskGrid.init();
     }
 
     @Override
@@ -243,6 +249,7 @@ public final class GridLayer extends AbstractLayer {
         radialCircleLineFar.dispose();
         radialThickLineFar.dispose();
         flatGrid.dispose();
+        diskGrid.dispose();
     }
 
     @Override

--- a/src/org/helioviewer/jhv/layers/GridLayer.java
+++ b/src/org/helioviewer/jhv/layers/GridLayer.java
@@ -1,5 +1,6 @@
 package org.helioviewer.jhv.layers;
 
+import java.awt.Color;
 import java.util.List;
 
 import org.helioviewer.jhv.astronomy.Position;
@@ -36,6 +37,8 @@ public final class GridLayer extends AbstractLayer {
     public static final double GRID_STEP_MIN = 5;
     public static final double GRID_STEP_MAX = 90;
     public static final double GRID_STEP = 0.1;
+    public static final double GRID_LINE_SCALE_MIN = 0.5;
+    public static final double GRID_LINE_SCALE_MAX = 5;
 
     // height of text in solar radii
     private static final float textScale = GridLabel.textScale;
@@ -52,6 +55,23 @@ public final class GridLayer extends AbstractLayer {
     private boolean showAxis = true;
     private boolean showLabels = true;
     private boolean showRadial = false;
+
+    // User-styleable grid line color, line opacity, label opacity and width (applied to the
+    // lat/lon graticule, the flat map grid, and the disk rings/spokes; the axis/Earth/radial
+    // overlays keep their colors). Line and label opacity are independent.
+    private Color gridColor = Color.RED;
+    private double gridAlpha = 1;
+    private double labelAlpha = 1;
+    private double gridLineScale = 1;
+
+    private byte[] gridColorBytes() {
+        return Colors.bytes(gridColor, gridAlpha);
+    }
+
+    // A label color faded to the label opacity (premultiplied; base is an opaque premultiplied color)
+    private float[] gridLabelColor(float[] base) {
+        return new float[]{(float) (base[0] * labelAlpha), (float) (base[1] * labelAlpha), (float) (base[2] * labelAlpha), (float) (base[3] * labelAlpha)};
+    }
 
     private final GLSLShape earthPoint = new GLSLShape(false);
     private final GLSLLine axesLine = new GLSLLine(false);
@@ -77,6 +97,10 @@ public final class GridLayer extends AbstractLayer {
         jo.put("showLabels", showLabels);
         jo.put("showRadial", showRadial);
         jo.put("type", Display.gridType);
+        jo.put("color", gridColor.getRGB());
+        jo.put("alpha", gridAlpha);
+        jo.put("labelAlpha", labelAlpha);
+        jo.put("lineScale", gridLineScale);
     }
 
     private void deserialize(JSONObject jo) {
@@ -86,6 +110,10 @@ public final class GridLayer extends AbstractLayer {
         showAxis = jo.optBoolean("showAxis", showAxis);
         showLabels = jo.optBoolean("showLabels", showLabels);
         showRadial = jo.optBoolean("showRadial", showRadial);
+        gridColor = new Color(jo.optInt("color", gridColor.getRGB()));
+        gridAlpha = Math.clamp(jo.optDouble("alpha", gridAlpha), 0, 1);
+        labelAlpha = Math.clamp(jo.optDouble("labelAlpha", labelAlpha), 0, 1);
+        gridLineScale = Math.clamp(jo.optDouble("lineScale", gridLineScale), GRID_LINE_SCALE_MIN, GRID_LINE_SCALE_MAX);
 
         String strGridType = jo.optString("type", Display.gridType.toString());
         try {
@@ -110,7 +138,7 @@ public final class GridLayer extends AbstractLayer {
         if (!isVisible[vp.idx])
             return;
         if (gridNeedsInit) {
-            GridMath.initGrid(gridLine, lonStep, latStep);
+            GridMath.initGrid(gridLine, lonStep, latStep, gridColorBytes());
             gridNeedsInit = false;
         }
 
@@ -123,7 +151,7 @@ public final class GridLayer extends AbstractLayer {
 
         Transform.pushView();
         Transform.rotateViewInverse(gridQuat);
-        gridLine.renderLine(vp, LINEWIDTH);
+        gridLine.renderLine(vp, LINEWIDTH * gridLineScale);
         Transform.popView();
 
         drawEarthCircles(vp, pixFactor, Sun.getEarth(viewpoint.time));
@@ -146,12 +174,12 @@ public final class GridLayer extends AbstractLayer {
                     radialCircleLineFar.renderLine(vp, LINEWIDTH);
                     radialThickLineFar.renderLine(vp, LINEWIDTH_THICK);
                     if (showLabels)
-                        drawRadialGridText(radialLabelsFar, ztext, R_LABEL_POS_FAR);
+                        drawRadialGridText(radialLabelsFar, ztext, R_LABEL_POS_FAR, gridLabelColor(Colors.MiddleGrayFloat));
                 } else {
                     radialCircleLine.renderLine(vp, LINEWIDTH);
                     radialThickLine.renderLine(vp, LINEWIDTH_THICK);
                     if (showLabels)
-                        drawRadialGridText(radialLabels, ztext, R_LABEL_POS);
+                        drawRadialGridText(radialLabels, ztext, R_LABEL_POS, gridLabelColor(Colors.MiddleGrayFloat));
                 }
             }
             Transform.popView();
@@ -163,9 +191,9 @@ public final class GridLayer extends AbstractLayer {
         if (!isVisible[vp.idx])
             return;
         if (mv.isDisk())
-            diskGrid.render(mv, vp, showLabels, lonStep);
+            diskGrid.render(mv, vp, showLabels, lonStep, gridColorBytes(), gridLineScale, labelAlpha);
         else
-            flatGrid.render(mv, vp, showLabels);
+            flatGrid.render(mv, vp, showLabels, gridColorBytes(), gridLineScale, labelAlpha);
     }
 
     private void drawEarthCircles(Viewport vp, double factor, Position p) {
@@ -178,9 +206,9 @@ public final class GridLayer extends AbstractLayer {
         Transform.popView();
     }
 
-    private static void drawRadialGridText(List<GridLabel> labels, float z, float[] labelPos) {
+    private static void drawRadialGridText(List<GridLabel> labels, float z, float[] labelPos, float[] color) {
         SdfTextRenderer renderer = GLText.renderer();
-        renderer.setColor(Colors.MiddleGrayFloat);
+        renderer.setColor(color);
         float textScaleFactor = textScale / renderer.getFontSize();
         float fuzz = 0.75f;
 
@@ -195,7 +223,7 @@ public final class GridLayer extends AbstractLayer {
 
     private void drawGridText(float z) {
         SdfTextRenderer renderer = GLText.renderer();
-        renderer.setColor(Colors.WhiteFloat);
+        renderer.setColor(gridLabelColor(Colors.WhiteFloat));
         // the scale factor has to be divided by the current font size
         float textScaleFactor = textScale / renderer.getFontSize();
 
@@ -216,7 +244,7 @@ public final class GridLayer extends AbstractLayer {
     @Override
     public void init() {
         gridLine.init();
-        GridMath.initGrid(gridLine, lonStep, latStep);
+        GridMath.initGrid(gridLine, lonStep, latStep, gridColorBytes());
         gridNeedsInit = false;
 
         axesLine.init();
@@ -314,6 +342,44 @@ public final class GridLayer extends AbstractLayer {
     public void setGridType(GridType gridType) {
         Display.setGridType(gridType);
         lonLabels = GridLabel.makeLonLabels(gridType, lonStep);
+        DisplayController.display();
+    }
+
+    public Color getGridColor() {
+        return gridColor;
+    }
+
+    public void setGridColor(Color _gridColor) {
+        gridColor = _gridColor;
+        gridNeedsInit = true; // the cached 3D grid buffer bakes in the color
+        DisplayController.display();
+    }
+
+    public double getGridAlpha() {
+        return gridAlpha;
+    }
+
+    public void setGridAlpha(double _gridAlpha) {
+        gridAlpha = Math.clamp(_gridAlpha, 0, 1);
+        gridNeedsInit = true;
+        DisplayController.display();
+    }
+
+    public double getLabelAlpha() {
+        return labelAlpha;
+    }
+
+    public void setLabelAlpha(double _labelAlpha) {
+        labelAlpha = Math.clamp(_labelAlpha, 0, 1);
+        DisplayController.display();
+    }
+
+    public double getGridLineScale() {
+        return gridLineScale;
+    }
+
+    public void setGridLineScale(double _gridLineScale) {
+        gridLineScale = Math.clamp(_gridLineScale, GRID_LINE_SCALE_MIN, GRID_LINE_SCALE_MAX);
         DisplayController.display();
     }
 

--- a/src/org/helioviewer/jhv/layers/GridLayer.java
+++ b/src/org/helioviewer/jhv/layers/GridLayer.java
@@ -39,6 +39,9 @@ public final class GridLayer extends AbstractLayer {
     public static final double GRID_STEP = 0.1;
     public static final double GRID_LINE_SCALE_MIN = 0.5;
     public static final double GRID_LINE_SCALE_MAX = 5;
+    public static final double GRID_LABEL_SIZE_MIN = 8;
+    public static final double GRID_LABEL_SIZE_MAX = 48;
+    public static final double GRID_LABEL_SIZE_REF = 22; // size at which each grid's labels keep their original size
 
     // height of text in solar radii
     private static final float textScale = GridLabel.textScale;
@@ -63,6 +66,10 @@ public final class GridLayer extends AbstractLayer {
     private double gridAlpha = 1;
     private double labelAlpha = 1;
     private double gridLineScale = 1;
+    // Disk-grid radius-label styling: font size (px at the reference scale) and the azimuth of the
+    // label spoke, in degrees clockwise from straight up (0 = a vertical column up the +y axis).
+    private double gridLabelSize = GRID_LABEL_SIZE_REF;
+    private double gridLabelAngle = 0;
 
     private byte[] gridColorBytes() {
         return Colors.bytes(gridColor, gridAlpha);
@@ -101,6 +108,8 @@ public final class GridLayer extends AbstractLayer {
         jo.put("alpha", gridAlpha);
         jo.put("labelAlpha", labelAlpha);
         jo.put("lineScale", gridLineScale);
+        jo.put("labelSize", gridLabelSize);
+        jo.put("labelAngle", gridLabelAngle);
     }
 
     private void deserialize(JSONObject jo) {
@@ -114,6 +123,8 @@ public final class GridLayer extends AbstractLayer {
         gridAlpha = Math.clamp(jo.optDouble("alpha", gridAlpha), 0, 1);
         labelAlpha = Math.clamp(jo.optDouble("labelAlpha", labelAlpha), 0, 1);
         gridLineScale = Math.clamp(jo.optDouble("lineScale", gridLineScale), GRID_LINE_SCALE_MIN, GRID_LINE_SCALE_MAX);
+        gridLabelSize = Math.clamp(jo.optDouble("labelSize", gridLabelSize), GRID_LABEL_SIZE_MIN, GRID_LABEL_SIZE_MAX);
+        gridLabelAngle = jo.optDouble("labelAngle", gridLabelAngle);
 
         String strGridType = jo.optString("type", Display.gridType.toString());
         try {
@@ -191,9 +202,9 @@ public final class GridLayer extends AbstractLayer {
         if (!isVisible[vp.idx])
             return;
         if (mv.isDisk())
-            diskGrid.render(mv, vp, showLabels, lonStep, gridColorBytes(), gridLineScale, labelAlpha);
+            diskGrid.render(mv, vp, showLabels, lonStep, gridColorBytes(), gridLineScale, labelAlpha, gridLabelSize, gridLabelAngle);
         else
-            flatGrid.render(mv, vp, showLabels, gridColorBytes(), gridLineScale, labelAlpha);
+            flatGrid.render(mv, vp, showLabels, gridColorBytes(), gridLineScale, labelAlpha, gridLabelSize);
     }
 
     private void drawEarthCircles(Viewport vp, double factor, Position p) {
@@ -206,10 +217,10 @@ public final class GridLayer extends AbstractLayer {
         Transform.popView();
     }
 
-    private static void drawRadialGridText(List<GridLabel> labels, float z, float[] labelPos, float[] color) {
+    private void drawRadialGridText(List<GridLabel> labels, float z, float[] labelPos, float[] color) {
         SdfTextRenderer renderer = GLText.renderer();
         renderer.setColor(color);
-        float textScaleFactor = textScale / renderer.getFontSize();
+        float textScaleFactor = (float) (textScale * gridLabelSize / GRID_LABEL_SIZE_REF) / renderer.getFontSize();
         float fuzz = 0.75f;
 
         GL.glDisable(GL.CULL_FACE);
@@ -224,8 +235,9 @@ public final class GridLayer extends AbstractLayer {
     private void drawGridText(float z) {
         SdfTextRenderer renderer = GLText.renderer();
         renderer.setColor(gridLabelColor(Colors.WhiteFloat));
-        // the scale factor has to be divided by the current font size
-        float textScaleFactor = textScale / renderer.getFontSize();
+        // the scale factor has to be divided by the current font size; the label-size slider scales
+        // it relative to the default (textScale is a fixed world size, so this stays resolution-invariant)
+        float textScaleFactor = (float) (textScale * gridLabelSize / GRID_LABEL_SIZE_REF) / renderer.getFontSize();
 
         renderer.begin3DRendering();
 
@@ -380,6 +392,24 @@ public final class GridLayer extends AbstractLayer {
 
     public void setGridLineScale(double _gridLineScale) {
         gridLineScale = Math.clamp(_gridLineScale, GRID_LINE_SCALE_MIN, GRID_LINE_SCALE_MAX);
+        DisplayController.display();
+    }
+
+    public double getGridLabelSize() {
+        return gridLabelSize;
+    }
+
+    public void setGridLabelSize(double _gridLabelSize) {
+        gridLabelSize = Math.clamp(_gridLabelSize, GRID_LABEL_SIZE_MIN, GRID_LABEL_SIZE_MAX);
+        DisplayController.display();
+    }
+
+    public double getGridLabelAngle() {
+        return gridLabelAngle;
+    }
+
+    public void setGridLabelAngle(double _gridLabelAngle) {
+        gridLabelAngle = _gridLabelAngle;
         DisplayController.display();
     }
 

--- a/src/org/helioviewer/jhv/layers/ImageLayer.java
+++ b/src/org/helioviewer/jhv/layers/ImageLayer.java
@@ -209,6 +209,9 @@ public class ImageLayer extends AbstractLayer implements View.DataHandler {
         if (!isVisible[vp.idx])
             return;
 
+        // The disk radial warp is now anchored linear-through-origin below the limb, so it
+        // renders a disk imager's on-disk pixels crisply (no polar smear) while keeping the
+        // off-limb locked to the grid — every layer uses its projection's shader directly.
         GLSLSolarShader shader = mv.mode().shader;
         shader.use();
         glImage.applyFilters(view.getFilter() == ImageFilter.Type.RHEF);

--- a/src/org/helioviewer/jhv/layers/filters/ImageFilterPanel.java
+++ b/src/org/helioviewer/jhv/layers/filters/ImageFilterPanel.java
@@ -103,6 +103,8 @@ public class ImageFilterPanel implements FilterDetails {
 
         filterPanel.add(filterCombo, BorderLayout.CENTER);
         filterPanel.add(upsilonButton, BorderLayout.LINE_END);
+        // Disk imagers render flat automatically in a disk projection (see ImageLayer.render
+        // and ImageLayers.isDiskImager); no manual toggle needed.
         buttonPanel.add(enhanceButton, BorderLayout.LINE_END);
     }
 

--- a/src/org/helioviewer/jhv/layers/grid/DiskGrid.java
+++ b/src/org/helioviewer/jhv/layers/grid/DiskGrid.java
@@ -1,0 +1,124 @@
+package org.helioviewer.jhv.layers.grid;
+
+import java.util.Arrays;
+
+import org.helioviewer.jhv.base.Colors;
+import org.helioviewer.jhv.display.Display;
+import org.helioviewer.jhv.display.MapScale;
+import org.helioviewer.jhv.display.MapView;
+import org.helioviewer.jhv.display.Viewport;
+import org.helioviewer.jhv.math.FastFormat;
+import org.helioviewer.jhv.opengl.BufVertex;
+import org.helioviewer.jhv.opengl.GLSLLine;
+import org.helioviewer.jhv.opengl.GLText;
+import org.helioviewer.jhv.opengl.text.SdfTextRenderer;
+
+// Radius rings and angular spokes for the disk display modes, drawn in the
+// isotropic disk world coordinates (center at the origin, rim at radius 0.5)
+public final class DiskGrid {
+
+    private static final int TEXT_SIZE = 22;
+    private static final int SUBDIVISIONS = 180;
+    private static final int MAX_RINGS = 16;
+    private static final double MIN_RING_SPACING = 0.04; // fraction of the disk radius
+    private static final double[] RING_FACTORS = {1, 2, 5};
+    private static final byte[] gridColor = Colors.Red;
+
+    private final GLSLLine line = new GLSLLine(false);
+
+    public void init() {
+        line.init();
+    }
+
+    public void dispose() {
+        line.dispose();
+    }
+
+    // spokeStep is the angular spacing of the radial spokes in degrees (the grid layer's
+    // longitude step; the latitude/coordinate-system controls do not map to a radial grid).
+    public void render(MapView mv, Viewport vp, boolean showLabels, double spokeStep) {
+        MapScale scale = mv.scale(vp);
+        double[] rings = chooseRings(scale);
+        updateLine(scale, rings, spokeStep);
+        line.renderLine(vp, GridMath.LINEWIDTH);
+        if (showLabels)
+            drawLabels(mv, vp, scale, rings);
+    }
+
+    // Ring radii at 1-2-5 decade steps within the radial range, decimated for legibility
+    private static double[] chooseRings(MapScale scale) {
+        double rMin = scale.getInterpolatedYValue(0);
+        double rMax = scale.getInterpolatedYValue(1);
+        double[] rings = new double[MAX_RINGS];
+        int count = 0;
+        double lastT = -1;
+        double decade = Math.pow(10, Math.floor(Math.log10(Math.max(rMin, 1e-3 * rMax))));
+        while (decade <= rMax && count < MAX_RINGS) {
+            for (double factor : RING_FACTORS) {
+                double r = factor * decade;
+                if (r < rMin || r > rMax || count == MAX_RINGS)
+                    continue;
+                double t = scale.getYValueInv(r) + .5;
+                if (t - lastT < MIN_RING_SPACING)
+                    continue;
+                rings[count++] = r;
+                lastT = t;
+            }
+            decade *= 10;
+        }
+        return Arrays.copyOf(rings, count);
+    }
+
+    private static float ringRho(MapScale scale, double r) {
+        return (float) (.5 * (scale.getYValueInv(r) + .5));
+    }
+
+    private void updateLine(MapScale scale, double[] rings, double spokeStep) {
+        int spokes = (int) Math.round(360 / spokeStep);
+        int noPoints = rings.length * (SUBDIVISIONS + 3) + 4 * spokes;
+        BufVertex vexBuf = new BufVertex(noPoints * GLSLLine.stride);
+
+        for (double r : rings) {
+            float rho = ringRho(scale, r);
+            for (int j = 0; j <= SUBDIVISIONS; j++) {
+                double a = 2 * Math.PI * j / SUBDIVISIONS;
+                float x = (float) (rho * Math.cos(a));
+                float y = (float) (rho * Math.sin(a));
+                if (j == 0)
+                    vexBuf.putVertex(x, y, 0, 1, Colors.Null);
+                vexBuf.putVertex(x, y, 0, 1, gridColor);
+                if (j == SUBDIVISIONS)
+                    vexBuf.putVertex(x, y, 0, 1, Colors.Null);
+            }
+        }
+
+        for (int s = 0; s < spokes; s++) {
+            double a = Math.toRadians(s * spokeStep);
+            float x = (float) (.5 * -Math.sin(a));
+            float y = (float) (.5 * Math.cos(a));
+            vexBuf.putVertex(0, 0, 0, 1, Colors.Null);
+            vexBuf.repeatVertex(gridColor);
+            vexBuf.putVertex(x, y, 0, 1, gridColor);
+            vexBuf.repeatVertex(Colors.Null);
+        }
+        line.setVertex(vexBuf);
+    }
+
+    private static void drawLabels(MapView mv, Viewport vp, MapScale scale, double[] rings) {
+        SdfTextRenderer renderer = GLText.renderer();
+        // Scale to the camera width (not min(width, 1)) so the labels keep a constant on-screen
+        // size at any zoom; the disk view normally spans several R_sun, where the cap shrank them.
+        double width = mv.cameraWidth(vp);
+        double worldTextHeight = TEXT_SIZE * Display.pixelScale[1] * width / vp.height;
+        float textScaleFactor = (float) (worldTextHeight / renderer.getFontSize());
+        float labelOffset = (float) (0.1 * worldTextHeight);
+
+        renderer.setColor(Colors.WhiteFloat);
+        renderer.begin3DRendering();
+        for (double r : rings) {
+            renderer.draw(FastFormat.rounded2(r), labelOffset, ringRho(scale, r) + labelOffset, 0, textScaleFactor);
+        }
+        renderer.end3DRendering();
+    }
+
+}

--- a/src/org/helioviewer/jhv/layers/grid/DiskGrid.java
+++ b/src/org/helioviewer/jhv/layers/grid/DiskGrid.java
@@ -3,7 +3,6 @@ package org.helioviewer.jhv.layers.grid;
 import java.util.Arrays;
 
 import org.helioviewer.jhv.base.Colors;
-import org.helioviewer.jhv.display.Display;
 import org.helioviewer.jhv.display.MapScale;
 import org.helioviewer.jhv.display.MapView;
 import org.helioviewer.jhv.display.Viewport;
@@ -17,7 +16,6 @@ import org.helioviewer.jhv.opengl.text.SdfTextRenderer;
 // isotropic disk world coordinates (center at the origin, rim at radius 0.5)
 public final class DiskGrid {
 
-    private static final int TEXT_SIZE = 22;
     private static final int SUBDIVISIONS = 180;
     private static final int MAX_RINGS = 16;
     private static final double MIN_RING_SPACING = 0.04; // fraction of the disk radius
@@ -35,13 +33,13 @@ public final class DiskGrid {
 
     // spokeStep is the angular spacing of the radial spokes in degrees (the grid layer's
     // longitude step; the latitude/coordinate-system controls do not map to a radial grid).
-    public void render(MapView mv, Viewport vp, boolean showLabels, double spokeStep, byte[] color, double lineScale, double labelAlpha) {
+    public void render(MapView mv, Viewport vp, boolean showLabels, double spokeStep, byte[] color, double lineScale, double labelAlpha, double labelSize, double labelAngle) {
         MapScale scale = mv.scale(vp);
         double[] rings = chooseRings(scale);
         updateLine(scale, rings, spokeStep, color);
         line.renderLine(vp, GridMath.LINEWIDTH * lineScale);
         if (showLabels)
-            drawLabels(mv, vp, scale, rings, labelAlpha);
+            drawLabels(mv, vp, scale, rings, labelAlpha, labelSize, labelAngle);
     }
 
     // Ring radii at 1-2-5 decade steps within the radial range, decimated for legibility
@@ -103,21 +101,31 @@ public final class DiskGrid {
         line.setVertex(vexBuf);
     }
 
-    private static void drawLabels(MapView mv, Viewport vp, MapScale scale, double[] rings, double labelAlpha) {
+    private static void drawLabels(MapView mv, Viewport vp, MapScale scale, double[] rings, double labelAlpha, double labelSize, double labelAngle) {
         SdfTextRenderer renderer = GLText.renderer();
-        // Scale to the camera width (not min(width, 1)) so the labels keep a constant on-screen
-        // size at any zoom; the disk view normally spans several R_sun, where the cap shrank them.
+        // Size the labels as a fraction of the camera FOV (world units), not a fixed pixel count:
+        // this keeps a constant on-screen size at any zoom AND makes the size invariant to the
+        // render resolution, so exporting a movie at a higher resolution keeps the same relative
+        // label size (the old pixel-based form scaled by the screen's stale pixelScale / vp.height).
+        // labelSize reads as ~pixels per 1000 px of frame width.
         double width = mv.cameraWidth(vp);
-        double worldTextHeight = TEXT_SIZE * Display.pixelScale[1] * width / vp.height;
+        double worldTextHeight = labelSize * width / 1000.;
         float textScaleFactor = (float) (worldTextHeight / renderer.getFontSize());
         float labelOffset = (float) (0.1 * worldTextHeight);
+
+        // Place the label column along a spoke at labelAngle (clockwise from straight up); the text
+        // stays upright. labelAngle = 0 reproduces the original vertical column up the +y axis.
+        double th = Math.toRadians(labelAngle);
+        double sin = Math.sin(th);
+        double cos = Math.cos(th);
 
         // White labels at the label opacity (premultiplied)
         float a = (float) labelAlpha;
         renderer.setColor(new float[]{a, a, a, a});
         renderer.begin3DRendering();
         for (double r : rings) {
-            renderer.draw(FastFormat.rounded2(r), labelOffset, ringRho(scale, r) + labelOffset, 0, textScaleFactor);
+            double rho = ringRho(scale, r);
+            renderer.draw(FastFormat.rounded2(r), (float) (sin * rho + labelOffset), (float) (cos * rho + labelOffset), 0, textScaleFactor);
         }
         renderer.end3DRendering();
     }

--- a/src/org/helioviewer/jhv/layers/grid/DiskGrid.java
+++ b/src/org/helioviewer/jhv/layers/grid/DiskGrid.java
@@ -22,7 +22,6 @@ public final class DiskGrid {
     private static final int MAX_RINGS = 16;
     private static final double MIN_RING_SPACING = 0.04; // fraction of the disk radius
     private static final double[] RING_FACTORS = {1, 2, 5};
-    private static final byte[] gridColor = Colors.Red;
 
     private final GLSLLine line = new GLSLLine(false);
 
@@ -36,13 +35,13 @@ public final class DiskGrid {
 
     // spokeStep is the angular spacing of the radial spokes in degrees (the grid layer's
     // longitude step; the latitude/coordinate-system controls do not map to a radial grid).
-    public void render(MapView mv, Viewport vp, boolean showLabels, double spokeStep) {
+    public void render(MapView mv, Viewport vp, boolean showLabels, double spokeStep, byte[] color, double lineScale, double labelAlpha) {
         MapScale scale = mv.scale(vp);
         double[] rings = chooseRings(scale);
-        updateLine(scale, rings, spokeStep);
-        line.renderLine(vp, GridMath.LINEWIDTH);
+        updateLine(scale, rings, spokeStep, color);
+        line.renderLine(vp, GridMath.LINEWIDTH * lineScale);
         if (showLabels)
-            drawLabels(mv, vp, scale, rings);
+            drawLabels(mv, vp, scale, rings, labelAlpha);
     }
 
     // Ring radii at 1-2-5 decade steps within the radial range, decimated for legibility
@@ -73,7 +72,7 @@ public final class DiskGrid {
         return (float) (.5 * (scale.getYValueInv(r) + .5));
     }
 
-    private void updateLine(MapScale scale, double[] rings, double spokeStep) {
+    private void updateLine(MapScale scale, double[] rings, double spokeStep, byte[] color) {
         int spokes = (int) Math.round(360 / spokeStep);
         int noPoints = rings.length * (SUBDIVISIONS + 3) + 4 * spokes;
         BufVertex vexBuf = new BufVertex(noPoints * GLSLLine.stride);
@@ -86,7 +85,7 @@ public final class DiskGrid {
                 float y = (float) (rho * Math.sin(a));
                 if (j == 0)
                     vexBuf.putVertex(x, y, 0, 1, Colors.Null);
-                vexBuf.putVertex(x, y, 0, 1, gridColor);
+                vexBuf.putVertex(x, y, 0, 1, color);
                 if (j == SUBDIVISIONS)
                     vexBuf.putVertex(x, y, 0, 1, Colors.Null);
             }
@@ -97,14 +96,14 @@ public final class DiskGrid {
             float x = (float) (.5 * -Math.sin(a));
             float y = (float) (.5 * Math.cos(a));
             vexBuf.putVertex(0, 0, 0, 1, Colors.Null);
-            vexBuf.repeatVertex(gridColor);
-            vexBuf.putVertex(x, y, 0, 1, gridColor);
+            vexBuf.repeatVertex(color);
+            vexBuf.putVertex(x, y, 0, 1, color);
             vexBuf.repeatVertex(Colors.Null);
         }
         line.setVertex(vexBuf);
     }
 
-    private static void drawLabels(MapView mv, Viewport vp, MapScale scale, double[] rings) {
+    private static void drawLabels(MapView mv, Viewport vp, MapScale scale, double[] rings, double labelAlpha) {
         SdfTextRenderer renderer = GLText.renderer();
         // Scale to the camera width (not min(width, 1)) so the labels keep a constant on-screen
         // size at any zoom; the disk view normally spans several R_sun, where the cap shrank them.
@@ -113,7 +112,9 @@ public final class DiskGrid {
         float textScaleFactor = (float) (worldTextHeight / renderer.getFontSize());
         float labelOffset = (float) (0.1 * worldTextHeight);
 
-        renderer.setColor(Colors.WhiteFloat);
+        // White labels at the label opacity (premultiplied)
+        float a = (float) labelAlpha;
+        renderer.setColor(new float[]{a, a, a, a});
         renderer.begin3DRendering();
         for (double r : rings) {
             renderer.draw(FastFormat.rounded2(r), labelOffset, ringRho(scale, r) + labelOffset, 0, textScaleFactor);

--- a/src/org/helioviewer/jhv/layers/grid/FlatGrid.java
+++ b/src/org/helioviewer/jhv/layers/grid/FlatGrid.java
@@ -18,11 +18,10 @@ public class FlatGrid {
 
     //private static final float TEXT_SCALE = GridLabel.textScale; // scalable text
     private static final int TEXT_SIZE = 12;
-    private static final double THICKNESS_PIXELS = 1.5;
+    private static final double BASE_THICKNESS_PIXELS = 1.5;
     private static final double[] ANGULAR_STEPS = {0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 15, 30, 45, 90, 180};
     private static final double[] LINEAR_STEP_FACTORS = {1, 2, 5, 10};
     private static final double TARGET_GRID_PIXELS = 12 * TEXT_SIZE;
-    private static final byte[] GRID_COLOR = Colors.Red;
     private static final byte[] AXIS_COLOR = Colors.Green;
     private static final double AXIS_EPSILON = 1e-9;
 
@@ -38,7 +37,7 @@ public class FlatGrid {
         shape.dispose();
     }
 
-    public void render(MapView mv, Viewport vp, boolean showLabels) {
+    public void render(MapView mv, Viewport vp, boolean showLabels, byte[] color, double lineScale, double labelAlpha) {
         double width = mv.cameraWidth(vp);
         MapScale scale = mv.scale(vp);
         double xCenter = 0.5 - mv.cameraTranslationX() / vp.aspect;
@@ -52,20 +51,22 @@ public class FlatGrid {
                 x0, x1, vp.width);
         Axis yAxis = buildAxis(scale, false, mv.isHpc() || mv.isLatitudinal(), false,
                 y0, y1, vp.height);
-        updateShape(xAxis, yAxis, mv, vp, width);
+        updateShape(xAxis, yAxis, mv, vp, width, color, lineScale);
         shape.renderShape(GL.TRIANGLES);
         if (showLabels)
-            drawLabels(xAxis, yAxis, mv, vp, width);
+            drawLabels(xAxis, yAxis, mv, vp, width, labelAlpha);
     }
 
-    private static void drawLabels(Axis xAxis, Axis yAxis, MapView mv, Viewport vp, double width) {
+    private static void drawLabels(Axis xAxis, Axis yAxis, MapView mv, Viewport vp, double width, double labelAlpha) {
         SdfTextRenderer renderer = GLText.renderer();
         //float textScaleFactor = 0.3f * TEXT_SCALE / renderer.getFontSize(); // scalable text
         double worldTextHeight = TEXT_SIZE * Display.pixelScale[1] * Math.min(width, 1) / vp.height;
         float textScaleFactor = (float) (worldTextHeight / renderer.getFontSize());
         float labelOffset = (float) (0.1 * worldTextHeight);
 
-        renderer.setColor(Colors.WhiteFloat);
+        // White labels at the label opacity (premultiplied)
+        float a = (float) labelAlpha;
+        renderer.setColor(new float[]{a, a, a, a});
         renderer.begin3DRendering();
         for (int i = 0; i < xAxis.labelValues().length; i++) {
             if (xAxis.positions()[i] == 0)
@@ -80,17 +81,18 @@ public class FlatGrid {
         renderer.end3DRendering();
     }
 
-    private void updateShape(Axis xAxis, Axis yAxis, MapView mv, Viewport vp, double width) {
+    private void updateShape(Axis xAxis, Axis yAxis, MapView mv, Viewport vp, double width, byte[] gridColor, double lineScale) {
         int noPoints = RasterLine.vertexCount(xAxis.positions().length + yAxis.positions().length);
         BufVertex vexBuf = new BufVertex(noPoints * GLSLShape.stride);
 
+        double thickness = BASE_THICKNESS_PIXELS * lineScale;
         for (int i = 0; i < xAxis.positions().length; i++) {
-            byte[] color = xAxis.positions()[i] == 0 ? AXIS_COLOR : GRID_COLOR;
-            RasterLine.putVertical(vp, width, mv.cameraTranslationX(), vp.aspect * xAxis.positions()[i], -0.5, 0.5, THICKNESS_PIXELS, color, vexBuf);
+            byte[] color = xAxis.positions()[i] == 0 ? AXIS_COLOR : gridColor;
+            RasterLine.putVertical(vp, width, mv.cameraTranslationX(), vp.aspect * xAxis.positions()[i], -0.5, 0.5, thickness, color, vexBuf);
         }
         for (int i = 0; i < yAxis.positions().length; i++) {
-            byte[] color = yAxis.positions()[i] == 0 ? AXIS_COLOR : GRID_COLOR;
-            RasterLine.putHorizontal(vp, width, mv.cameraTranslationY(), -0.5 * vp.aspect, 0.5 * vp.aspect, yAxis.positions()[i], THICKNESS_PIXELS, color, vexBuf);
+            byte[] color = yAxis.positions()[i] == 0 ? AXIS_COLOR : gridColor;
+            RasterLine.putHorizontal(vp, width, mv.cameraTranslationY(), -0.5 * vp.aspect, 0.5 * vp.aspect, yAxis.positions()[i], thickness, color, vexBuf);
         }
         shape.setVertex(vexBuf);
     }

--- a/src/org/helioviewer/jhv/layers/grid/FlatGrid.java
+++ b/src/org/helioviewer/jhv/layers/grid/FlatGrid.java
@@ -1,7 +1,6 @@
 package org.helioviewer.jhv.layers.grid;
 
 import org.helioviewer.jhv.base.Colors;
-import org.helioviewer.jhv.display.Display;
 import org.helioviewer.jhv.display.GridType;
 import org.helioviewer.jhv.display.MapScale;
 import org.helioviewer.jhv.display.MapView;
@@ -37,7 +36,7 @@ public class FlatGrid {
         shape.dispose();
     }
 
-    public void render(MapView mv, Viewport vp, boolean showLabels, byte[] color, double lineScale, double labelAlpha) {
+    public void render(MapView mv, Viewport vp, boolean showLabels, byte[] color, double lineScale, double labelAlpha, double labelSize) {
         double width = mv.cameraWidth(vp);
         MapScale scale = mv.scale(vp);
         double xCenter = 0.5 - mv.cameraTranslationX() / vp.aspect;
@@ -54,13 +53,16 @@ public class FlatGrid {
         updateShape(xAxis, yAxis, mv, vp, width, color, lineScale);
         shape.renderShape(GL.TRIANGLES);
         if (showLabels)
-            drawLabels(xAxis, yAxis, mv, vp, width, labelAlpha);
+            drawLabels(xAxis, yAxis, mv, vp, width, labelAlpha, labelSize);
     }
 
-    private static void drawLabels(Axis xAxis, Axis yAxis, MapView mv, Viewport vp, double width, double labelAlpha) {
+    private static void drawLabels(Axis xAxis, Axis yAxis, MapView mv, Viewport vp, double width, double labelAlpha, double labelSize) {
         SdfTextRenderer renderer = GLText.renderer();
-        //float textScaleFactor = 0.3f * TEXT_SCALE / renderer.getFontSize(); // scalable text
-        double worldTextHeight = TEXT_SIZE * Display.pixelScale[1] * Math.min(width, 1) / vp.height;
+        // Size as a fraction of the (capped) camera FOV, not a pixel count, so the labels are
+        // invariant to the render resolution (export at a higher resolution keeps the same relative
+        // size). labelSize is the grid layer's label-size slider; the min(width, 1) cap keeps the
+        // labels from growing without bound when zoomed out.
+        double worldTextHeight = labelSize * Math.min(width, 1) / 1000.;
         float textScaleFactor = (float) (worldTextHeight / renderer.getFontSize());
         float labelOffset = (float) (0.1 * worldTextHeight);
 

--- a/src/org/helioviewer/jhv/layers/grid/GridMath.java
+++ b/src/org/helioviewer/jhv/layers/grid/GridMath.java
@@ -16,8 +16,6 @@ public class GridMath {
     private static final byte[] axisNorthColor = Colors.Red;
     private static final byte[] axisSouthColor = Colors.Blue;
     private static final byte[] earthLineColor = Colors.Yellow;
-    private static final byte[] color1 = Colors.Red;
-    private static final byte[] color2 = Colors.Green;
 
     private static final float earthPointSize = 0.02f;
 
@@ -112,7 +110,7 @@ public class GridMath {
         radialThickLine.setVertex(thickBuf);
     }
 
-    public static void initGrid(GLSLLine gridLine, double lonstepDegrees, double latstepDegrees) {
+    public static void initGrid(GLSLLine gridLine, double lonstepDegrees, double latstepDegrees, byte[] color) {
         int no_lon_steps = ((int) Math.ceil(360 / lonstepDegrees)) / 2 + 1;
         int no_lat_steps = ((int) Math.ceil(180 / latstepDegrees)) / 2;
         int HALFDIVISIONS = SUBDIVISIONS / 2;
@@ -131,7 +129,7 @@ public class GridMath {
                     if (i == 0) {
                         vexBuf.putVertex(rotv, Colors.Null);
                     }
-                    vexBuf.putVertex(rotv, i % 2 == 0 ? color1 : color2);
+                    vexBuf.putVertex(rotv, color);
                     if (i == HALFDIVISIONS) {
                         vexBuf.putVertex(rotv, Colors.Null);
                     }
@@ -153,7 +151,7 @@ public class GridMath {
                     if (i == 0) {
                         vexBuf.putVertex(v, Colors.Null);
                     }
-                    vexBuf.putVertex(v, i % 2 == 0 ? color1 : color2);
+                    vexBuf.putVertex(v, color);
                     if (i == HALFDIVISIONS) {
                         vexBuf.putVertex(v, Colors.Null);
                     }

--- a/src/org/helioviewer/jhv/layers/selector/GridLayerOptions.java
+++ b/src/org/helioviewer/jhv/layers/selector/GridLayerOptions.java
@@ -8,11 +8,15 @@ import java.util.function.DoubleConsumer;
 
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
+import javax.swing.JComponent;
 import javax.swing.JFormattedTextField;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
+import javax.swing.event.AncestorEvent;
+import javax.swing.event.AncestorListener;
 
+import org.helioviewer.jhv.app.state.ViewState;
 import org.helioviewer.jhv.display.Display;
 import org.helioviewer.jhv.display.GridType;
 import org.helioviewer.jhv.gui.component.JHVSpinner;
@@ -21,6 +25,12 @@ import org.helioviewer.jhv.layers.GridLayer;
 
 @SuppressWarnings("serial")
 final class GridLayerOptions extends JPanel {
+
+    // The disk projection draws a radial ring/spoke grid; these lat/lon-graticule controls have
+    // no meaning there (Longitude maps to the spoke spacing, so it stays enabled), so they are
+    // greyed out while a disk projection is active.
+    private final JComponent[] nonDiskControls;
+    private final ViewState.ModeListener modeListener = this::applyProjectionEnablement;
 
     GridLayerOptions(GridLayer layer) {
         setLayout(new GridBagLayout());
@@ -34,7 +44,8 @@ final class GridLayerOptions extends JPanel {
 
         c0.gridx = 1;
         c0.anchor = GridBagConstraints.LINE_END;
-        add(createToggle("Solar axis", layer.isShowAxis(), layer::setShowAxis), c0);
+        JCheckBox axisToggle = createToggle("Solar axis", layer.isShowAxis(), layer::setShowAxis);
+        add(axisToggle, c0);
 
         c0.gridx = 3;
         c0.anchor = GridBagConstraints.LINE_END;
@@ -44,14 +55,16 @@ final class GridLayerOptions extends JPanel {
 
         c0.gridx = 1;
         c0.anchor = GridBagConstraints.LINE_END;
-        add(createToggle("Radial grid", layer.isShowRadial(), layer::setShowRadial), c0);
+        JCheckBox radialToggle = createToggle("Radial grid", layer.isShowRadial(), layer::setShowRadial);
+        add(radialToggle, c0);
 
         c0.gridx = 2;
         c0.anchor = GridBagConstraints.LINE_END;
         add(new JLabel("Grid type ", JLabel.RIGHT), c0);
         c0.gridx = 3;
         c0.anchor = GridBagConstraints.LINE_START;
-        add(createGridTypeBox(layer), c0);
+        JComboBox<GridType> gridTypeBox = createGridTypeBox(layer);
+        add(gridTypeBox, c0);
 
         c0.gridy = 2;
 
@@ -69,7 +82,34 @@ final class GridLayerOptions extends JPanel {
 
         c0.gridx = 3;
         c0.anchor = GridBagConstraints.LINE_START;
-        add(createGridResolutionSpinner(layer.getLatStep(), layer::setLatStep), c0);
+        JHVSpinner latSpinner = createGridResolutionSpinner(layer.getLatStep(), layer::setLatStep);
+        add(latSpinner, c0);
+
+        nonDiskControls = new JComponent[]{axisToggle, radialToggle, gridTypeBox, latSpinner};
+        applyProjectionEnablement();
+        // Track the projection only while the panel is on screen, so the listener is not leaked
+        addAncestorListener(new AncestorListener() {
+            @Override
+            public void ancestorAdded(AncestorEvent event) {
+                ViewState.addModeListener(modeListener);
+                applyProjectionEnablement();
+            }
+
+            @Override
+            public void ancestorRemoved(AncestorEvent event) {
+                ViewState.removeModeListener(modeListener);
+            }
+
+            @Override
+            public void ancestorMoved(AncestorEvent event) {
+            }
+        });
+    }
+
+    private void applyProjectionEnablement() {
+        boolean enabled = !ViewState.getProjection().isDisk();
+        for (JComponent control : nonDiskControls)
+            control.setEnabled(enabled);
     }
 
     private JCheckBox createToggle(String text, boolean initialValue, Consumer<Boolean> onChange) {

--- a/src/org/helioviewer/jhv/layers/selector/GridLayerOptions.java
+++ b/src/org/helioviewer/jhv/layers/selector/GridLayerOptions.java
@@ -1,12 +1,18 @@
 package org.helioviewer.jhv.layers.selector;
 
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Graphics;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.DoubleConsumer;
 
+import javax.swing.Icon;
+import javax.swing.JButton;
 import javax.swing.JCheckBox;
+import javax.swing.JColorChooser;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JFormattedTextField;
@@ -19,6 +25,7 @@ import javax.swing.event.AncestorListener;
 import org.helioviewer.jhv.app.state.ViewState;
 import org.helioviewer.jhv.display.Display;
 import org.helioviewer.jhv.display.GridType;
+import org.helioviewer.jhv.gui.component.JHVSlider;
 import org.helioviewer.jhv.gui.component.JHVSpinner;
 import org.helioviewer.jhv.gui.component.TerminatedFormatterFactory;
 import org.helioviewer.jhv.layers.GridLayer;
@@ -85,6 +92,38 @@ final class GridLayerOptions extends JPanel {
         JHVSpinner latSpinner = createGridResolutionSpinner(layer.getLatStep(), layer::setLatStep);
         add(latSpinner, c0);
 
+        c0.gridy = 3;
+
+        c0.gridx = 0;
+        c0.anchor = GridBagConstraints.LINE_END;
+        add(new JLabel("Color ", JLabel.RIGHT), c0);
+        c0.gridx = 1;
+        c0.anchor = GridBagConstraints.LINE_START;
+        add(createColorButton(layer), c0);
+
+        c0.gridx = 2;
+        c0.anchor = GridBagConstraints.LINE_END;
+        add(new JLabel("Line opacity ", JLabel.RIGHT), c0);
+        c0.gridx = 3;
+        c0.anchor = GridBagConstraints.LINE_START;
+        add(createOpacitySlider("Grid line opacity", layer.getGridAlpha(), layer::setGridAlpha), c0);
+
+        c0.gridy = 4;
+
+        c0.gridx = 0;
+        c0.anchor = GridBagConstraints.LINE_END;
+        add(new JLabel("Line width ", JLabel.RIGHT), c0);
+        c0.gridx = 1;
+        c0.anchor = GridBagConstraints.LINE_START;
+        add(createLineWidthSlider(layer), c0);
+
+        c0.gridx = 2;
+        c0.anchor = GridBagConstraints.LINE_END;
+        add(new JLabel("Label opacity ", JLabel.RIGHT), c0);
+        c0.gridx = 3;
+        c0.anchor = GridBagConstraints.LINE_START;
+        add(createOpacitySlider("Grid label opacity", layer.getLabelAlpha(), layer::setLabelAlpha), c0);
+
         nonDiskControls = new JComponent[]{axisToggle, radialToggle, gridTypeBox, latSpinner};
         applyProjectionEnablement();
         // Track the projection only while the panel is on screen, so the listener is not leaked
@@ -110,6 +149,57 @@ final class GridLayerOptions extends JPanel {
         boolean enabled = !ViewState.getProjection().isDisk();
         for (JComponent control : nonDiskControls)
             control.setEnabled(enabled);
+    }
+
+    private JButton createColorButton(GridLayer layer) {
+        JButton button = new JButton(swatchIcon(layer.getGridColor()));
+        button.setToolTipText("Grid line color");
+        button.addActionListener(e -> {
+            Color chosen = JColorChooser.showDialog(this, "Grid color", layer.getGridColor());
+            if (chosen != null) {
+                layer.setGridColor(chosen);
+                button.setIcon(swatchIcon(chosen));
+            }
+        });
+        return button;
+    }
+
+    private static Icon swatchIcon(Color color) {
+        return new Icon() {
+            @Override
+            public int getIconWidth() {
+                return 24;
+            }
+
+            @Override
+            public int getIconHeight() {
+                return 12;
+            }
+
+            @Override
+            public void paintIcon(Component c, Graphics g, int x, int y) {
+                g.setColor(color);
+                g.fillRect(x, y, getIconWidth(), getIconHeight());
+                g.setColor(Color.DARK_GRAY);
+                g.drawRect(x, y, getIconWidth() - 1, getIconHeight() - 1);
+            }
+        };
+    }
+
+    private static JHVSlider createOpacitySlider(String tooltip, double initial, DoubleConsumer setter) {
+        JHVSlider slider = new JHVSlider(0, 100, (int) Math.round(initial * 100));
+        slider.setToolTipText(tooltip);
+        slider.addChangeListener(e -> setter.accept(slider.getValue() / 100.));
+        return slider;
+    }
+
+    private static JHVSlider createLineWidthSlider(GridLayer layer) {
+        int min = (int) Math.round(GridLayer.GRID_LINE_SCALE_MIN * 10);
+        int max = (int) Math.round(GridLayer.GRID_LINE_SCALE_MAX * 10);
+        JHVSlider slider = new JHVSlider(min, max, (int) Math.round(layer.getGridLineScale() * 10));
+        slider.setToolTipText("Grid line width");
+        slider.addChangeListener(e -> layer.setGridLineScale(slider.getValue() / 10.));
+        return slider;
     }
 
     private JCheckBox createToggle(String text, boolean initialValue, Consumer<Boolean> onChange) {

--- a/src/org/helioviewer/jhv/layers/selector/GridLayerOptions.java
+++ b/src/org/helioviewer/jhv/layers/selector/GridLayerOptions.java
@@ -37,6 +37,7 @@ final class GridLayerOptions extends JPanel {
     // no meaning there (Longitude maps to the spoke spacing, so it stays enabled), so they are
     // greyed out while a disk projection is active.
     private final JComponent[] nonDiskControls;
+    private final JComponent[] diskOnlyControls;
     private final ViewState.ModeListener modeListener = this::applyProjectionEnablement;
 
     GridLayerOptions(GridLayer layer) {
@@ -124,7 +125,28 @@ final class GridLayerOptions extends JPanel {
         c0.anchor = GridBagConstraints.LINE_START;
         add(createOpacitySlider("Grid label opacity", layer.getLabelAlpha(), layer::setLabelAlpha), c0);
 
+        c0.gridy = 5;
+
+        c0.gridx = 0;
+        c0.anchor = GridBagConstraints.LINE_END;
+        add(new JLabel("Label size ", JLabel.RIGHT), c0);
+        c0.gridx = 1;
+        c0.anchor = GridBagConstraints.LINE_START;
+        JHVSlider labelSizeSlider = createLabelSizeSlider(layer);
+        add(labelSizeSlider, c0);
+
+        c0.gridx = 2;
+        c0.anchor = GridBagConstraints.LINE_END;
+        add(new JLabel("Label angle ", JLabel.RIGHT), c0);
+        c0.gridx = 3;
+        c0.anchor = GridBagConstraints.LINE_START;
+        JHVSlider labelAngleSlider = createLabelAngleSlider(layer);
+        add(labelAngleSlider, c0);
+
         nonDiskControls = new JComponent[]{axisToggle, radialToggle, gridTypeBox, latSpinner};
+        // The radius-label spoke angle only makes sense for the disk grid, so enable it only in a
+        // disk projection. Label size stays available alongside label opacity (always enabled).
+        diskOnlyControls = new JComponent[]{labelAngleSlider};
         applyProjectionEnablement();
         // Track the projection only while the panel is on screen, so the listener is not leaked
         addAncestorListener(new AncestorListener() {
@@ -146,9 +168,11 @@ final class GridLayerOptions extends JPanel {
     }
 
     private void applyProjectionEnablement() {
-        boolean enabled = !ViewState.getProjection().isDisk();
+        boolean disk = ViewState.getProjection().isDisk();
         for (JComponent control : nonDiskControls)
-            control.setEnabled(enabled);
+            control.setEnabled(!disk);
+        for (JComponent control : diskOnlyControls)
+            control.setEnabled(disk);
     }
 
     private JButton createColorButton(GridLayer layer) {
@@ -199,6 +223,22 @@ final class GridLayerOptions extends JPanel {
         JHVSlider slider = new JHVSlider(min, max, (int) Math.round(layer.getGridLineScale() * 10));
         slider.setToolTipText("Grid line width");
         slider.addChangeListener(e -> layer.setGridLineScale(slider.getValue() / 10.));
+        return slider;
+    }
+
+    private static JHVSlider createLabelSizeSlider(GridLayer layer) {
+        int min = (int) GridLayer.GRID_LABEL_SIZE_MIN;
+        int max = (int) GridLayer.GRID_LABEL_SIZE_MAX;
+        JHVSlider slider = new JHVSlider(min, max, (int) Math.round(layer.getGridLabelSize()));
+        slider.setToolTipText("Disk grid label font size");
+        slider.addChangeListener(e -> layer.setGridLabelSize(slider.getValue()));
+        return slider;
+    }
+
+    private static JHVSlider createLabelAngleSlider(GridLayer layer) {
+        JHVSlider slider = new JHVSlider(0, 360, (int) Math.round(layer.getGridLabelAngle()));
+        slider.setToolTipText("Disk grid radius-label spoke angle (° clockwise from vertical)");
+        slider.addChangeListener(e -> layer.setGridLabelAngle(slider.getValue()));
         return slider;
     }
 

--- a/src/org/helioviewer/jhv/math/PolarBasis.java
+++ b/src/org/helioviewer/jhv/math/PolarBasis.java
@@ -11,8 +11,12 @@ public final class PolarBasis {
     }
 
     public static double angle(Vec3 v) {
+        return angle(v.x, v.y);
+    }
+
+    public static double angle(double x, double y) {
         // Polar basis: 0 at north, increasing anti-clockwise.
-        double theta = Math.atan2(-v.x, v.y);
+        double theta = Math.atan2(-x, y);
         if (theta < 0)
             theta += 2 * Math.PI;
         return theta;

--- a/src/org/helioviewer/jhv/opengl/GLRenderer.java
+++ b/src/org/helioviewer/jhv/opengl/GLRenderer.java
@@ -36,6 +36,7 @@ public final class GLRenderer {
             case Latitudinal -> createConstantScales(viewports, MapScale.lati);
             case LogPolar -> createConstantScales(viewports, MapScale.logpolar(ImageLayers.getLargestRadialSize()));
             case Polar -> createConstantScales(viewports, MapScale.polar(ImageLayers.getLargestRadialSize()));
+            case RadialWarp -> createConstantScales(viewports, MapScale.diskPower(ImageLayers.getLargestRadialSize()));
         };
     }
 

--- a/src/org/helioviewer/jhv/opengl/GLSLSolarShader.java
+++ b/src/org/helioviewer/jhv/opengl/GLSLSolarShader.java
@@ -17,6 +17,7 @@ public class GLSLSolarShader extends GLSLShader {
     public static final GLSLSolarShader lati = new GLSLSolarShader("/glsl/solar.vert", "/glsl/solarLati.frag", true);
     public static final GLSLSolarShader polar = new GLSLSolarShader("/glsl/solar.vert", "/glsl/solarPolar.frag", true);
     public static final GLSLSolarShader logpolar = new GLSLSolarShader("/glsl/solar.vert", "/glsl/solarLogPolar.frag", true);
+    public static final GLSLSolarShader diskPower = new GLSLSolarShader("/glsl/solar.vert", "/glsl/solarDiskPower.frag", true);
 
     private final boolean hasCommon;
 
@@ -39,7 +40,9 @@ public class GLSLSolarShader extends GLSLShader {
     private static final int PROJECTION_SIZE = projectionBuf.capacity() * 4;
 
     private static GLBO screenBO;
-    private static final FloatBuffer screenBuf = BufferUtils.newFloatBuffer(16 + 4 + 4 + 4);
+    // mat4 (16) + vec4 viewport (4) + 6 scalars (iaspect, xStart, xStop, yStart, yStop, yParam),
+    // padded to the std140 16-byte block boundary
+    private static final FloatBuffer screenBuf = BufferUtils.newFloatBuffer(16 + 4 + 6 + 2);
     private static final int SCREEN_SIZE = screenBuf.capacity() * 4;
 
     private static GLBO displayBO;
@@ -58,6 +61,7 @@ public class GLSLSolarShader extends GLSLShader {
         lati._init(lati.hasCommon);
         polar._init(polar.hasCommon);
         logpolar._init(logpolar.hasCommon);
+        diskPower._init(diskPower.hasCommon);
     }
 
     private static void setupCommonBlocks(int programID) {
@@ -90,6 +94,7 @@ public class GLSLSolarShader extends GLSLShader {
         lati._dispose();
         polar._dispose();
         logpolar._dispose();
+        diskPower._dispose();
         wcsBO.delete();
         projectionBO.delete();
         screenBO.delete();
@@ -146,7 +151,7 @@ public class GLSLSolarShader extends GLSLShader {
         inv.flip();
         screenBuf.put(vp.glslArray).put((float) (1 / vp.aspect));
         screenBuf.put((float) scale.getInterpolatedXValue(0)).put((float) scale.getInterpolatedXValue(1));
-        screenBuf.put((float) scale.getYstart()).put((float) scale.getYstop());
+        screenBuf.put((float) scale.getYstart()).put((float) scale.getYstop()).put((float) scale.getYParam());
 
         screenBuf.flip();
         screenBO.setBufferData(SCREEN_SIZE, screenBuf); // always changes


### PR DESCRIPTION
Second half of the grid work (split out of #326). Stacked on #326.

## What this adds

- **Label size** — one slider scales the grid labels in *every* projection (ortho lat/lon, radial, flat, disk). Sized as a fraction of the field of view rather than in logical pixels, so a movie exported at a different resolution keeps the same relative label size.
- **Label angle (θ)** — places the radius-label spoke at an azimuth in the disk grid, so labels can be moved off whatever the image is doing. Glyphs stay upright.

The angle control is disk-only and greys out elsewhere; the size control is always active. Defaults reproduce the current look exactly.
