### PR TITLE
Add GOES-R SUVI to the FOV catalog

### DIFF
--- a/src/org/helioviewer/jhv/layers/fov/FOVCatalog.java
+++ b/src/org/helioviewer/jhv/layers/fov/FOVCatalog.java
@@ -62,6 +62,7 @@ public final class FOVCatalog {
         plat.add(new FOVInstrument("AIA", FOVInstrument.FOVType.RECTANGULAR, 0, (0.6 * 4096) / 3600., (0.6 * 4096) / 3600., jpo));
         plat.add(new FOVInstrument("HMI", FOVInstrument.FOVType.RECTANGULAR, 0, (0.6 * 4096) / 3600., (0.6 * 4096) / 3600., jpo));
         plat.add(new FOVInstrument("SWAP", FOVInstrument.FOVType.RECTANGULAR, 0, (3.1646941 * 1024) / 3600., (3.1646941 * 1024) / 3600., jpo));
+        plat.add(new FOVInstrument("SUVI", FOVInstrument.FOVType.RECTANGULAR, 0, (2.5 * 1280) / 3600., (2.5 * 1280) / 3600., jpo));
         plat.add(new FOVInstrument("ASPIICS", FOVInstrument.FOVType.RECTANGULAR, .5850334, 1.6, 1.6, jpo));
         addPlatform(plat);
     }


### PR DESCRIPTION
GOES-R SUVI is already recognized as an image source, but it has no entry in the
FOV catalog, so its field of view can't be drawn alongside the other Earth-orbit
instruments.

One line, following the AIA/HMI/SWAP pattern: SUVI is 1280 x 1280 at 2.5"/pixel,
so the extent is `(2.5 * 1280) / 3600.` degrees square, rectangular, no offset.

```java
plat.add(new FOVInstrument("SUVI", FOVInstrument.FOVType.RECTANGULAR, 0, (2.5 * 1280) / 3600., (2.5 * 1280) / 3600., jpo));
```

Independent of everything else I have open — nothing depends on it and it
depends on nothing.