### PR TITLE
Fall back to a memory-only JPIP cache when the disk cache is locked

### DIFF
--- a/src/org/helioviewer/jhv/view/j2k/jpip/JPIPCacheManager.java
+++ b/src/org/helioviewer/jhv/view/j2k/jpip/JPIPCacheManager.java
@@ -12,6 +12,7 @@ import org.helioviewer.jhv.io.Directories;
 import org.helioviewer.jhv.io.FileUtils;
 
 import org.ehcache.Cache;
+import org.ehcache.CacheManager;
 import org.ehcache.PersistentCacheManager;
 import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.CacheManagerBuilder;
@@ -30,8 +31,8 @@ public class JPIPCacheManager {
     private static final Path levelCacheDir = Path.of(Directories.CACHE.getPath(), "JPIPLevel-4");
     private static final Path streamCacheDir = Path.of(Directories.CACHE.getPath(), "JPIPStream-4");
 
-    private static PersistentCacheManager levelManager;
-    private static PersistentCacheManager streamManager;
+    private static CacheManager levelManager;
+    private static CacheManager streamManager;
     private static Cache<String, Integer> levelCache;
     private static Cache<String, JPIPStream> streamCache;
     private static Thread hook;
@@ -41,23 +42,42 @@ public class JPIPCacheManager {
 
         ExpiryPolicy<Object, Object> expiryPolicy = ExpiryPolicyBuilder.timeToIdleExpiration(Duration.ofDays(7));
 
-        levelManager = CacheManagerBuilder.newCacheManagerBuilder()
-                .with(CacheManagerBuilder.persistence(levelCacheDir.toString()))
-                .withCache("JPIPLevel", CacheConfigurationBuilder
-                        .newCacheConfigurationBuilder(String.class, Integer.class,
-                                ResourcePoolsBuilder.newResourcePoolsBuilder()
-                                        .heap(10000, EntryUnit.ENTRIES)
-                                        .disk(10, MemoryUnit.MB, true))
-                        .withExpiry(expiryPolicy))
-                .build(true);
-        streamManager = CacheManagerBuilder.newCacheManagerBuilder()
-                .with(CacheManagerBuilder.persistence(streamCacheDir.toString()))
-                .withCache("JPIPStream", CacheConfigurationBuilder
-                        .newCacheConfigurationBuilder(String.class, JPIPStream.class,
-                                ResourcePoolsBuilder.newResourcePoolsBuilder()
-                                        .disk(8, MemoryUnit.GB, true))
-                        .withExpiry(expiryPolicy))
-                .build(true);
+        try {
+            levelManager = CacheManagerBuilder.newCacheManagerBuilder()
+                    .with(CacheManagerBuilder.persistence(levelCacheDir.toString()))
+                    .withCache("JPIPLevel", CacheConfigurationBuilder
+                            .newCacheConfigurationBuilder(String.class, Integer.class,
+                                    ResourcePoolsBuilder.newResourcePoolsBuilder()
+                                            .heap(10000, EntryUnit.ENTRIES)
+                                            .disk(10, MemoryUnit.MB, true))
+                            .withExpiry(expiryPolicy))
+                    .build(true);
+            streamManager = CacheManagerBuilder.newCacheManagerBuilder()
+                    .with(CacheManagerBuilder.persistence(streamCacheDir.toString()))
+                    .withCache("JPIPStream", CacheConfigurationBuilder
+                            .newCacheConfigurationBuilder(String.class, JPIPStream.class,
+                                    ResourcePoolsBuilder.newResourcePoolsBuilder()
+                                            .disk(8, MemoryUnit.GB, true))
+                            .withExpiry(expiryPolicy))
+                    .build(true);
+        } catch (Exception e) { // disk cache locked by another running instance
+            Log.warn("JPIP disk cache is in use by another JHelioviewer instance, using a memory-only cache for this session", e);
+            close();
+            levelManager = CacheManagerBuilder.newCacheManagerBuilder()
+                    .withCache("JPIPLevel", CacheConfigurationBuilder
+                            .newCacheConfigurationBuilder(String.class, Integer.class,
+                                    ResourcePoolsBuilder.newResourcePoolsBuilder()
+                                            .heap(10000, EntryUnit.ENTRIES))
+                            .withExpiry(expiryPolicy))
+                    .build(true);
+            streamManager = CacheManagerBuilder.newCacheManagerBuilder()
+                    .withCache("JPIPStream", CacheConfigurationBuilder
+                            .newCacheConfigurationBuilder(String.class, JPIPStream.class,
+                                    ResourcePoolsBuilder.newResourcePoolsBuilder()
+                                            .heap(256, EntryUnit.ENTRIES)) // entries, not bytes: streams are too large to size-of
+                            .withExpiry(expiryPolicy))
+                    .build(true);
+        }
 
         if (hook == null) {
             hook = new Thread(JPIPCacheManager::close);
@@ -70,6 +90,8 @@ public class JPIPCacheManager {
 
     @Nullable
     public static JPIPStream get(@Nonnull String key, int level) {
+        if (levelCache == null)
+            return null;
         try {
             Integer clevel = levelCache.get(key);
             if (clevel != null && clevel <= level)
@@ -81,6 +103,8 @@ public class JPIPCacheManager {
     }
 
     public static void put(@Nonnull String key, int level, @Nonnull JPIPStream stream) {
+        if (levelCache == null)
+            return;
         try {
             Integer clevel = levelCache.get(key);
             if (clevel == null || clevel > level) {
@@ -102,8 +126,10 @@ public class JPIPCacheManager {
 
     private static void close() {
         try {
-            levelManager.close();
-            streamManager.close();
+            if (levelManager != null)
+                levelManager.close();
+            if (streamManager != null)
+                streamManager.close();
         } catch (Exception e) {
             Log.error(e);
         }
@@ -112,8 +138,10 @@ public class JPIPCacheManager {
     public static void clear() {
         close();
         try {
-            levelManager.destroy();
-            streamManager.destroy();
+            if (levelManager instanceof PersistentCacheManager persistent)
+                persistent.destroy();
+            if (streamManager instanceof PersistentCacheManager persistent)
+                persistent.destroy();
         } catch (Exception e) {
             Log.error(e);
         }


### PR DESCRIPTION
A second running instance holds the ehcache persistence lock on `Cache/JPIPLevel-4`. When that happens `levelCache` and `streamCache` are left null, and every `get`/`put` afterwards logs a SEVERE NullPointerException, several per second, while streaming carries on working anyway. The session is usable and the log is unreadable.

This catches the persistent manager build failure, logs one warning, and rebuilds both caches heap-only (level 10000 entries, stream 256) so the session keeps a working cache instead of none. `get`/`put` also bail out null-safely if initialization failed entirely, and `clear()` only destroys managers that are actually persistent.

The second-instance case is easy to hit without meaning to: any secondary window, or a crashed process whose lock has not been released yet.

Verified with a two-process headless check. A second `init()` against a held lock logs the single warning, round-trips `put`/`get` through the heap cache, and 500 hammered `get`/`put` pairs produce no log spam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)