### PR TITLE
Make ant jar self-sufficient, and find the Metal host from the jar's own directory

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -111,7 +111,10 @@
         </javac>
     </target>
 
-    <target name="jar" depends="compile">
+    <!-- build-metal-host too: `ant clean jar` without it ships a jar whose Metal bridge dies at
+         startup, and only `ant run` used to pull the dylib in. Harmless off macOS (the exec is
+         failonerror=false and xcrun simply is not there). -->
+    <target name="jar" depends="compile,build-metal-host">
         <delete file="${jarfile}"/>
         <copy file="version.properties" tofile="${bin}/version.properties"/>
         <replace file="${bin}/version.properties" token="@@VERSION" value="${version}"/>

--- a/src/org/helioviewer/jhv/opengl/angle/AngleLibraries.java
+++ b/src/org/helioviewer/jhv/opengl/angle/AngleLibraries.java
@@ -49,6 +49,18 @@ final class AngleLibraries {
             Path path = MACOS_NATIVE_DIR.resolve(fileName).toAbsolutePath();
             if (Files.exists(path))
                 return path;
+            // The path above is cwd-relative and a launch from elsewhere (java -jar with an
+            // absolute path, the zip's launchers) never finds it: ANGLE warmup then dies with
+            // nothing to say. The dylib sits beside the jar in the repo and in the zip, so ask
+            // where this class was loaded from. The notarized .app needs neither branch: its
+            // dylib is injected into the jar and the resource fallback below serves it.
+            try {
+                Path code = Path.of(AngleLibraries.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+                Path byJar = code.getParent().resolve(MACOS_NATIVE_DIR).resolve(fileName);
+                if (Files.isRegularFile(byJar))
+                    return byJar;
+            } catch (Exception ignore) {
+            }
         }
 
         String resourcePath = Platform.getResourceDir() + fileName;


### PR DESCRIPTION
Two build robustness fixes, from footguns that both fired on the same day.

**`ant clean jar` ships a jar whose Metal bridge dies at startup.** Only `ant run` depended on `build-metal-host`, so a jar built with `jar` alone has no `libjhvmetalhost.dylib` and ANGLE warmup fails. `jar` now depends on it too. Harmless off macOS: the exec is already `failonerror="false"`.

**The dylib lookup was relative to the working directory.** Launching the jar from anywhere other than the repo root killed ANGLE warmup with a bare null. The lookup now also tries the directory the jar itself was loaded from, which covers both the repo layout and the zip layout.

The notarized `.app` is unaffected either way: deploy injects the dylib into the jar and the classpath-resource fallback serves it. This only changes the developer and zip paths, which are the ones that were broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)