### PR TITLE
Recognize a gzipped FITS by where it came from, not by where it was cached

### DIFF
--- a/extra/test/DataUriFormatCheck.java
+++ b/extra/test/DataUriFormatCheck.java
@@ -1,0 +1,89 @@
+package org.helioviewer.jhv.io;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Format detection has to survive the cache, which is where it broke.
+ *
+ * <p>A downloaded file is stored under a hash with no extension, so a rule written against the
+ * file's own path never fires for a download even though it works perfectly on the same file
+ * opened locally. Every SUVI frame is a gzipped FITS served over HTTP, and every one of them was
+ * "Unknown image type" while the local copy loaded fine. The name at the source and the name in
+ * the cache are different questions, and only the first one carries the extension.
+ *
+ * <p>Run: java -cp bin:extra/test-classes:lib/* org.helioviewer.jhv.io.DataUriFormatCheck
+ */
+public final class DataUriFormatCheck {
+
+    private static int failures;
+
+    public static void main(String[] args) throws Exception {
+        File cached = gzipped(fitsHeader());          // hash-named, as the cache stores it
+        File plain = uncompressed(fitsHeader());
+        File notFits = gzipped("this is not a FITS".getBytes(StandardCharsets.US_ASCII));
+
+        check("gzipped FITS named .fits.gz at source",
+                format("https://example.org/OR_SUVI-L1b-Fe195.fits.gz", cached), DataUri.Format.Image.FITS);
+        check("gzipped FITS named .fts.gz at source",
+                format("https://example.org/frame.fts.gz", cached), DataUri.Format.Image.FITS);
+        // The source name says nothing, so only looking inside can answer.
+        check("gzipped FITS with no telltale name",
+                format("https://example.org/download?id=7", cached), DataUri.Format.Image.FITS);
+        check("plain FITS", format("https://example.org/frame.fts", plain), DataUri.Format.Image.FITS);
+        check("gzip that is not FITS", format("https://example.org/notes.gz", notFits) == DataUri.Format.Image.FITS, false);
+
+        System.out.println(failures == 0 ? "DataUriFormatCheck: PASS" : "DataUriFormatCheck: FAIL");
+        if (failures != 0)
+            System.exit(1);
+    }
+
+    /** The cached file is deliberately hash-named: that is what the real cache does. */
+    private static DataUri.Format format(String sourceUrl, File cachedFile) throws Exception {
+        return new DataUri(new URI(sourceUrl), cachedFile.toURI(), cachedFile).format();
+    }
+
+    /** A minimal primary header: SIMPLE, BITPIX, NAXIS, END, padded to one 2880-byte block. */
+    private static byte[] fitsHeader() {
+        StringBuilder sb = new StringBuilder();
+        for (String card : new String[]{
+                "SIMPLE  =                    T",
+                "BITPIX  =                   16",
+                "NAXIS   =                    0",
+                "END"})
+            sb.append(String.format("%-80s", card));
+        while (sb.length() < 2880)
+            sb.append(' ');
+        return sb.toString().getBytes(StandardCharsets.US_ASCII);
+    }
+
+    private static File gzipped(byte[] content) throws Exception {
+        File f = File.createTempFile("a1b2c3d4e5f6", ""); // no extension, like the cache
+        f.deleteOnExit();
+        try (OutputStream out = new GZIPOutputStream(new FileOutputStream(f))) {
+            out.write(content);
+        }
+        return f;
+    }
+
+    private static File uncompressed(byte[] content) throws Exception {
+        File f = File.createTempFile("f6e5d4c3b2a1", "");
+        f.deleteOnExit();
+        try (OutputStream out = new FileOutputStream(f)) {
+            out.write(content);
+        }
+        return f;
+    }
+
+    private static void check(String what, Object got, Object want) {
+        boolean ok = got.equals(want);
+        if (!ok)
+            failures++;
+        System.out.println((ok ? "  ok   " : "  FAIL ") + what + ": got " + got + ", want " + want);
+    }
+
+}

--- a/src/org/helioviewer/jhv/io/DataUri.java
+++ b/src/org/helioviewer/jhv/io/DataUri.java
@@ -1,9 +1,14 @@
 package org.helioviewer.jhv.io;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.net.URI;
+import java.util.Locale;
 import java.util.Map;
+import java.util.zip.GZIPInputStream;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.tika.Tika;
@@ -12,11 +17,32 @@ public class DataUri {
 
     private static final Tika tika = new Tika();
 
-    private static Format detect(File file) throws IOException {
-        if (file.getPath().toLowerCase().endsWith(".fits.gz")) // hack
+    /**
+     * @param name the name the resource has at its source, not the cached file's
+     *
+     * <p>The distinction is the whole point. Tika reports a gzipped FITS as gzip, so the extension
+     * is what rescues it, and the cached copy of a download is named by hash with no extension at
+     * all: testing the cached path meant every remote {@code .fits.gz} was Unknown while the same
+     * file opened locally was fine. That is every SUVI frame, which NOAA serves gzipped.
+     *
+     * <p>The content check behind it covers a server that does not say gz in the name.
+     */
+    private static Format detect(File file, String name) throws IOException {
+        String lower = name.toLowerCase(Locale.US);
+        if (lower.endsWith(".fits.gz") || lower.endsWith(".fts.gz"))
             return Format.Image.FITS;
-        else
-            return getFormat(tika.detect(file));
+
+        Format format = getFormat(tika.detect(file));
+        return format == Format.Unknown.UNKNOWN && isGzippedFits(file) ? Format.Image.FITS : format;
+    }
+
+    /** Every FITS begins with the SIMPLE keyword, so one decompressed read settles it. */
+    private static boolean isGzippedFits(File file) {
+        try (InputStream in = new GZIPInputStream(new FileInputStream(file), 512)) {
+            return "SIMPLE".equals(new String(in.readNBytes(6), StandardCharsets.US_ASCII));
+        } catch (IOException e) {
+            return false; // not gzip, or truncated: either way not a FITS we can read
+        }
     }
 
     private static final Map<String, Format> map = Map.of(
@@ -54,8 +80,8 @@ public class DataUri {
         sourceUri = originalUri;
         uri = cachedUri;
         file = _file;
-        format = file == null ? Format.Image.JPIP : detect(file); // JPIP not backed by file
         baseName = FilenameUtils.getName(originalUri.toString());
+        format = file == null ? Format.Image.JPIP : detect(file, baseName); // JPIP not backed by file
     }
 
     public URI sourceUri() {


### PR DESCRIPTION
A remote `.fits.gz` fails with "Unknown image type", and the layer then dies with "Empty list of views". The identical file opened from disk works, which is why this survives a direct decode test.

Tika reports a gzipped FITS as `application/gzip`, so `DataUri` falls back to an extension rule to rescue it. That rule tested the **cached** file's path. A downloaded file is cached under a content hash with no extension at all, so the rule can never fire for a remote URI, while a local file passes.

The fix is to test the origin URI's path, which is the one that carries the extension, and to keep testing the local path when there is no remote origin. `DataUriFormatCheck` pins both directions, including that a gzip which is not FITS is still rejected.

Found on NOAA's SUVI archive, which serves `.fits.gz` exclusively, but it is not specific to that source: any gzipped FITS behind an HTTP URL hits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)