### PR TITLE
Tell a machine with no network apart from a server that failed

### DIFF
--- a/extra/test/ErrorAdviceCheck.java
+++ b/extra/test/ErrorAdviceCheck.java
@@ -1,0 +1,79 @@
+package org.helioviewer.jhv.gui;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+
+/**
+ * An error dialog must not send the user to the wrong place.
+ *
+ * <p>Every error used to carry the same footnote offering the Helioviewer API bug tracker, which
+ * meant a laptop with no wifi failing to list the PUNCH archive at the SDAC advised filing a report
+ * against a server that had never heard from it. The judgement is now made from the exception type
+ * rather than its text, because "No route to host" IS the whole message the user sees and matching
+ * on that string would break on the first rewording.
+ *
+ * <p>This pins the classification, which is the part with a right answer. The wording is not.
+ *
+ * <p>Run: java -cp bin:extra/test-classes org.helioviewer.jhv.gui.ErrorAdviceCheck
+ */
+public final class ErrorAdviceCheck {
+
+    private static int failures;
+
+    public static void main(String[] args) throws Exception {
+        // The machine cannot reach anything: not the archive's fault, and not reportable.
+        offline(new NoRouteToHostException("No route to host"), "no route to host");
+        offline(new UnknownHostException("umbra.nascom.nasa.gov"), "DNS failure");
+        offline(new ConnectException("Connection refused"), "connection refused");
+
+        // Wrapped, which is how they actually arrive: through a client, through an executor.
+        offline(new IOException("listing failed", new NoRouteToHostException("No route to host")),
+                "a network failure wrapped once");
+        offline(new RuntimeException("query", new IOException("read", new UnknownHostException("host"))),
+                "a network failure wrapped twice");
+
+        // Reached the server and it went wrong there. That IS worth reporting.
+        online(new SocketTimeoutException("Read timed out"), "a timeout means something answered slowly");
+        online(new IOException("HTTP 500"), "a server error");
+        online(new IllegalStateException("bad response"), "a parsing failure");
+        online(null, "no exception at all");
+
+        // A cycle in the cause chain must not hang the dialog. Java forbids a one-element cycle,
+        // so this is the shortest one it will actually let you build.
+        RuntimeException a = new RuntimeException("a");
+        RuntimeException b = new RuntimeException("b");
+        a.initCause(b);
+        b.initCause(a);
+        online(a, "a cyclic cause chain");
+
+        if (failures != 0)
+            throw new AssertionError(failures + " error-advice failure(s)");
+        System.out.println("ErrorAdviceCheck: PASS");
+    }
+
+    private static void offline(Throwable t, String what) throws Exception {
+        expect(classify(t), what + " must be reported as a local network problem");
+    }
+
+    private static void online(Throwable t, String what) throws Exception {
+        expect(!classify(t), what + " must NOT be blamed on the network");
+    }
+
+    /** MessageHandler.isOffline, reached reflectively: it is private and has no business not being. */
+    private static boolean classify(Throwable t) throws Exception {
+        java.lang.reflect.Method m = MessageHandler.class.getDeclaredMethod("isOffline", Throwable.class);
+        m.setAccessible(true);
+        return (Boolean) m.invoke(null, t);
+    }
+
+    private static void expect(boolean ok, String what) {
+        if (!ok) {
+            failures++;
+            System.out.println("FAIL: " + what);
+        }
+    }
+
+}

--- a/src/org/helioviewer/jhv/app/Message.java
+++ b/src/org/helioviewer/jhv/app/Message.java
@@ -5,6 +5,14 @@ public class Message {
     public interface Handler {
         void err(String title, Object msg);
 
+        /**
+         * The same report, with the exception that caused it. The default drops the cause, so a
+         * handler only implements this if it has something to say about the KIND of failure.
+         */
+        default void err(String title, Object msg, Throwable cause) {
+            err(title, msg);
+        }
+
         void warn(String title, Object msg);
 
         void fatalErr(String msg);
@@ -18,6 +26,17 @@ public class Message {
 
     public static void err(String title, Object msg) {
         handler.err(title, msg);
+    }
+
+    /**
+     * Report a failure along with what threw it.
+     *
+     * <p>The body still comes from {@code msg}: the cause is passed so the dialog can tell a
+     * machine with no network from a server that is misbehaving, which are the same sentence and
+     * very different situations.
+     */
+    public static void err(String title, Object msg, Throwable cause) {
+        handler.err(title, msg, cause);
     }
 
     public static void warn(String title, Object msg) {

--- a/src/org/helioviewer/jhv/gui/MessageHandler.java
+++ b/src/org/helioviewer/jhv/gui/MessageHandler.java
@@ -3,6 +3,8 @@ package org.helioviewer.jhv.gui;
 import java.awt.Dimension;
 import java.awt.EventQueue;
 
+import javax.annotation.Nullable;
+
 import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
@@ -23,11 +25,46 @@ final class MessageHandler implements Message.Handler {
     }
 
     @Override
+    public void err(String title, Object msg, Throwable cause) {
+        show(title, msg, JOptionPane.ERROR_MESSAGE, cause);
+    }
+
+    @Override
     public void fatalErr(String msg) {
         JOptionPane.showMessageDialog(null, Message.format(msg), "Fatal Error", JOptionPane.ERROR_MESSAGE);
     }
 
     private static void show(String title, Object msg, int type) {
+        show(title, msg, type, null);
+    }
+
+    /**
+     * Whether this failure is the network being unreachable rather than anything going wrong at
+     * the other end.
+     *
+     * <p>Decided from the exception type rather than from its text. "No route to host" and
+     * "Connection refused" are the whole message a user sees, and matching on those strings would
+     * break the moment a locale or a library reworded them, while the type is the JDK's own
+     * statement of what happened.
+     */
+    private static boolean isOffline(@Nullable Throwable cause) {
+        int depth = 0;
+        // Bounded rather than walked to the end: a cause chain can be a cycle (Java forbids only
+        // the one-element case), and a dialog that hangs on a malformed exception is a worse bug
+        // than the one it was trying to report.
+        for (Throwable t = cause; t != null; t = t.getCause(), depth++) {
+            if (depth > 32)
+                return false;
+            if (t instanceof java.net.UnknownHostException
+                    || t instanceof java.net.NoRouteToHostException
+                    || t instanceof java.net.ConnectException
+                    || t instanceof java.net.PortUnreachableException)
+                return true;
+        }
+        return false;
+    }
+
+    private static void show(String title, Object msg, int type, @Nullable Throwable cause) {
         if (Thread.currentThread().isInterrupted())
             return;
 
@@ -42,8 +79,17 @@ final class MessageHandler implements Message.Handler {
             HTMLPane report = new HTMLPane();
             report.setOpaque(false);
             report.addHyperlinkListener(DesktopIntegration.hyperOpenURL);
-            String url = "https://github.com/Helioviewer-Project/api/issues/new";
-            report.setText("If this is a JPIP connection failure, you can open a bug report for the<br>Helioviewer server at <a href='" + url + "'>" + url + "</a>.");
+            // A machine with no network is not a server bug, and offering a bug tracker for it
+            // sends the user to file a report against an archive that never heard from them.
+            // The link was previously shown on EVERY error, which is how "No route to host" from
+            // the PUNCH archive at the SDAC came to suggest reporting it to Helioviewer.
+            if (isOffline(cause)) {
+                report.setText("This machine could not reach the network. Nothing is wrong at the "
+                        + "other end; a session saved with its data downloaded will still open.");
+            } else {
+                String url = "https://github.com/Helioviewer-Project/api/issues/new";
+                report.setText("If this is a JPIP connection failure, you can open a bug report for the<br>Helioviewer server at <a href='" + url + "'>" + url + "</a>.");
+            }
 
             JOptionPane optionPane = new JOptionPane();
             optionPane.setMessage(new Object[]{report, scrollPane});

--- a/src/org/helioviewer/jhv/thread/Task.java
+++ b/src/org/helioviewer/jhv/thread/Task.java
@@ -41,7 +41,7 @@ public final class Task {
 
     private static void defaultOnFailure(String logContext, Throwable t, String errorMessage) {
         Log.error(logContext, t);
-        Message.err(errorMessage, t.getMessage());
+        Message.err(errorMessage, t.getMessage(), t);
     }
 
     private Task() {}


### PR DESCRIPTION
Every error dialog offers the Helioviewer API issue tracker, on the reasoning that the failure might be a JPIP connection problem. Most are not. A laptop that has lost its wifi, failing to list an archive that is not Helioviewer's, currently advises the user to file a bug against a server that never heard from them.

`Message` can now carry the exception alongside its text, so a handler can say something about the *kind* of failure. A local-network failure says so and offers no tracker. **Everything else is unchanged, including the existing wording**, so this only removes the advice where it was wrong.

Two decisions worth flagging for review:

- **Classified by exception type**, not by matching `"No route to host"`. That string is the whole message the user sees, and matching on it would break on the first rewording or non-English locale. The types are `UnknownHostException`, `NoRouteToHostException`, `ConnectException`, `PortUnreachableException`.
- **`SocketTimeoutException` is deliberately not treated as offline.** Something answered, just slowly, and that is worth reporting.

The cause-chain walk is bounded at 32. Java forbids a one-element cycle but not a two-element one, and a dialog that hangs on a malformed exception would be a worse bug than the one it was reporting.

`ErrorAdviceCheck` pins the classification, which has a right answer, including wrapped causes and the cycle. It does not pin the wording, which does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)