### PR TITLE
Accept "degree" and "degrees" as CUNIT

### DIFF
--- a/src/org/helioviewer/jhv/metadata/WcsInterpreter.java
+++ b/src/org/helioviewer/jhv/metadata/WcsInterpreter.java
@@ -84,9 +84,7 @@ final class WcsInterpreter {
 
     private static double arcsecPerUnit(String unit) {
         return switch (unit.strip().toLowerCase()) {
-            // Not FITS-standard, but written in the wild: IDL-produced synoptic maps emit
-            // "degrees". Without these they reach default and the image is scaled by 1/3600.
-            case "deg", "degree", "degrees" -> 3600.;
+            case "deg", "degree", "degrees" -> 3600.; // Accept alternative non-standard spellings.
             case "arcmin" -> 60.;
             case "mas" -> .001;
             case "rad" -> 180. * 3600. / Math.PI;

--- a/src/org/helioviewer/jhv/metadata/WcsInterpreter.java
+++ b/src/org/helioviewer/jhv/metadata/WcsInterpreter.java
@@ -84,7 +84,9 @@ final class WcsInterpreter {
 
     private static double arcsecPerUnit(String unit) {
         return switch (unit.strip().toLowerCase()) {
-            case "deg" -> 3600.;
+            // Not FITS-standard, but written in the wild: IDL-produced synoptic maps emit
+            // "degrees". Without these they reach default and the image is scaled by 1/3600.
+            case "deg", "degree", "degrees" -> 3600.;
             case "arcmin" -> 60.;
             case "mas" -> .001;
             case "rad" -> 180. * 3600. / Math.PI;


### PR DESCRIPTION
A `CUNIT1`/`CUNIT2` of `degree` or `degrees` currently reaches the `default` arm of `arcsecPerUnit` and is treated as arcseconds, so the plate scale comes out a factor of 3600 too small.

```java
case "deg" -> 3600.;
...
default -> 1.;
```

Neither spelling is FITS-standard, which is why they are easy to miss, but IDL-written synoptic maps do emit them. The failure is silent: the header parses, the layer loads, and the geometry is simply wrong.

Found while integrating your WCS rework (`94c1ba63c` and its neighbours) into a fork that had independently hit the same units problem, and had been carrying a narrower `deg`/`degree`/`degrees` check. Yours is the better shape, so this just adds the two spellings to it rather than proposing anything else.

One observation rather than a change, since it is a matter of taste: `arcsec` has no case of its own and works only because `default -> 1.` happens to be the arcsec factor. An explicit `case "arcsec" -> 1.;` would make the fallback's meaning ("assume arcseconds") a decision rather than a coincidence. Left out of this diff deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)